### PR TITLE
docs: OTA firmware update design spec

### DIFF
--- a/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
+++ b/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
@@ -223,7 +223,7 @@ Display a message, poll `digitalRead(36)` for 10 seconds, print result to serial
 ```cpp
 struct UpdateInfo {
     uint64_t version;       // YYYYMMDDNNN — exceeds uint32_t max, must be 64-bit
-    uint32_t size;          // exact byte count from manifest (informational only; not passed to esp_ota_begin)
+    uint32_t size;          // exact byte count from manifest (informational only; not passed to esp_ota_begin; may be used for progress display)
     char sha256[65];        // 64 hex chars + null terminator
     char signature[200];    // base64 DER ECDSA signature (~100 chars; 200 gives headroom)
     char url[128];          // URL to raw binary on Pi json-store
@@ -244,14 +244,16 @@ struct UpdateInfo {
 static const uint64_t COMPILED_VERSION = FIRMWARE_VERSION;
 ```
 
-### `OTAManager::checkForUpdate()`
+### `OTAManager::checkForUpdate(const char* manifestUrl, UpdateInfo& info)`
 
-- `GET /ota-firmware/data` via plain HTTP (same pattern as `BatteryLogger`)
+- `GET manifestUrl` via plain HTTP (same pattern as `BatteryLogger`)
 - Parse with `ArduinoJson` (`StaticJsonDocument<1024>` — raw content is ~250–300 bytes; ArduinoJson tree overhead for 6 fields adds ~288 bytes, totalling ~550–600 bytes worst case; 1024 gives safe headroom)
 - Compare `version` field to compiled-in `FIRMWARE_VERSION`
-- Return `true` + populate `UpdateInfo` struct if manifest version is greater
+- Return `true` + populate `info` struct if manifest version is greater
 
-### `OTAManager::performUpdate()`
+### `OTAManager::performUpdate(const UpdateInfo& info)`
+
+**API note:** `OTAManager` uses the ESP-IDF native OTA API directly (`esp_ota_ops.h`, `esp_app_format.h`), not the Arduino `Update` library. The two are mutually exclusive — do not mix them. The native API is required here because it exposes `esp_ota_abort()` and partition-level control.
 
 Call sequence (order is critical for safe abort):
 
@@ -288,8 +290,11 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
     display.clearDisplay();
     display.setFont(/* 35pt */);
     display.setCursor(50, 350);
+    // display.printf() is not part of the Inkplate/Print API. Use snprintf + print.
     // PRIu64 requires <inttypes.h>; %llu is broken on ESP32 Arduino (newlib-nano).
-    display.printf("Firmware v%" PRIu64 " available\nPress WAKE to install\n(30s to skip)", info.version);
+    char otaBuf[128];
+    snprintf(otaBuf, sizeof(otaBuf), "Firmware v%" PRIu64 " available\nPress WAKE to install\n(30s to skip)", info.version);
+    display.print(otaBuf);
     // Battery shown on splash for user awareness; a second read is taken at
     // confirmation time for the safety threshold check (intentional — the
     // confirmation-time reading is what matters for flash safety).

--- a/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
+++ b/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
@@ -298,7 +298,8 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
     // Battery shown on splash for user awareness; a second read is taken at
     // confirmation time for the safety threshold check (intentional — the
     // confirmation-time reading is what matters for flash safety).
-    display.printf("\nBattery: %.2fV", (display.readBattery() + ADC_OFFSET));
+    snprintf(otaBuf, sizeof(otaBuf), "\nBattery: %.2fV", (display.readBattery() + ADC_OFFSET));
+    display.print(otaBuf);
     display.display();
 
     // Poll GPIO 36 for 30s

--- a/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
+++ b/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
@@ -75,7 +75,7 @@ The SPIFFS image is flashed once via USB using esptool. OTA never touches the SP
 
 ### New Module: `src/display/AssetLoader`
 
-Wraps SPIFFS open + `ps_malloc` + `GFXfont` construction. Called once per boot before rendering. Must call `SPIFFS.begin()` (or require the caller to have done so) before any file operations — failure to mount SPIFFS produces a silent null return from `SPIFFS.open()`. Provides:
+Wraps SPIFFS open + `ps_malloc` + `GFXfont` construction. Called once per boot before rendering. `AssetLoader` calls `SPIFFS.begin()` internally before any file operations — it does not require the caller to do so. Failure to mount SPIFFS produces a silent null return from `SPIFFS.open()`, so `AssetLoader` must check the return value and log/assert on failure. Provides:
 - `uint8_t* loadImage(const char* path)` — loads raw image binary into PSRAM
 - `GFXfont* loadFont(const char* bitmapPath, const char* glyphPath, ...)` — loads font data into PSRAM, constructs and returns `GFXfont` struct
 
@@ -161,12 +161,14 @@ python3 tools/ota_publish.py \
 
 Steps:
 1. Read `VERSION` file
-2. Read `.bin`, compute SHA-256
-3. Sign SHA-256 digest with ECDSA P-256 private key
-4. Base64-encode DER signature
+2. Read `.bin` as raw bytes; compute SHA-256 digest (32 bytes)
+3. Sign the 32-byte SHA-256 digest using ECDSA P-256 with `Prehashed()` — pass the digest bytes, not the raw binary, to the `cryptography` library's `sign()` call: `key.sign(digest_bytes, ec.ECDSA(utils.Prehashed(hashes.SHA256())))`. This matches what `mbedtls_ecdsa_verify()` on the device expects: the hash input, not the raw binary.
+4. Base64-encode the DER-encoded signature
 5. Write `manifest.json` locally
 6. `PUT` manifest to `http://<pi-host>/ota-firmware/data`
 7. `PUT` raw binary to `http://<pi-host>/ota-firmware/binaries/firmware.bin`
+
+**Sign/verify contract:** Both sides operate on the SHA-256 digest bytes (32 bytes), not the raw firmware. Python signs the pre-computed digest; `mbedtls_ecdsa_verify()` receives the same 32-byte digest. This must be consistent — if Python uses `ECDSA(SHA256())` (library hashes internally), `mbedtls_ecdsa_verify()` must receive the raw binary, which is not feasible at ~1.25MB. Use `Prehashed` on the Python side.
 
 ### Manifest Format
 
@@ -229,6 +231,19 @@ struct UpdateInfo {
 };
 ```
 
+### Constants
+
+```cpp
+// In Weather_Station_2.cpp (or a dedicated config header)
+#define OTA_MANIFEST_URL "http://192.168.1.2:5000/ota-firmware/data"
+```
+
+`FIRMWARE_VERSION` is injected at compile time by CMake from the `VERSION` file as a bare integer. Declare it as `uint64_t` at the point of use to avoid truncation:
+
+```cpp
+static const uint64_t COMPILED_VERSION = FIRMWARE_VERSION;
+```
+
 ### `OTAManager::checkForUpdate()`
 
 - `GET /ota-firmware/data` via plain HTTP (same pattern as `BatteryLogger`)
@@ -240,12 +255,14 @@ struct UpdateInfo {
 
 Call sequence (order is critical for safe abort):
 
-1. `esp_ota_begin(update_partition, OTA_SIZE_UNKNOWN, &handle)` — obtain handle. `OTA_SIZE_UNKNOWN` is used because the manifest `size` field is not covered by the ECDSA signature (which signs only the binary's SHA-256 digest, not the manifest JSON). On a plain HTTP channel, passing an attacker-controlled `size` to `esp_ota_begin()` is unsafe. Content length is validated implicitly when the SHA-256 over the streamed bytes matches the manifest's `sha256` field.
+1. `esp_ota_begin(update_partition, OTA_SIZE_UNKNOWN, &handle)` — obtain handle. `OTA_SIZE_UNKNOWN` avoids a second source of truth: the manifest `size` field is informational only and not signed. Content integrity is validated entirely by the SHA-256 + ECDSA checks in steps 3–4; the actual byte count is implicitly verified when the SHA-256 over the streamed bytes matches the manifest `sha256` field.
 2. For each 4KB chunk: `esp_ota_write(handle, chunk, len)` + SHA-256 accumulator update
 3. After stream: verify computed SHA-256 against manifest `sha256` field
 4. If SHA-256 passes: verify ECDSA P-256 signature over SHA-256 digest using `mbedtls_ecdsa_verify()` with embedded public key
 5. If both checks pass: `esp_ota_end(handle)` → `esp_ota_set_boot_partition()` → `esp_restart()`
 6. If either check fails: `esp_ota_abort(handle)` → return `false` (running partition untouched)
+
+**HTTP timeout:** Set `HTTPClient::setTimeout()` to a reasonable value (e.g., 30s) before beginning the stream. On a local network the Pi is unlikely to disappear mid-stream, but without a timeout the device will hang indefinitely with WiFi active if the connection drops.
 
 **Important:** `esp_ota_end()` is called only after both SHA-256 and ECDSA checks pass. Calling `esp_ota_abort(handle)` before `esp_ota_end()` is always safe — it discards the incomplete write. Calling abort *after* `esp_ota_end()` is undefined; this ordering prevents that.
 
@@ -271,8 +288,7 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
     display.clearDisplay();
     display.setFont(/* 35pt */);
     display.setCursor(50, 350);
-    // %llu is broken on ESP32 Arduino (newlib-nano omits 64-bit printf).
-    // Use PRIu64 from <inttypes.h> or format the version separately.
+    // PRIu64 requires <inttypes.h>; %llu is broken on ESP32 Arduino (newlib-nano).
     display.printf("Firmware v%" PRIu64 " available\nPress WAKE to install\n(30s to skip)", info.version);
     // Battery shown on splash for user awareness; a second read is taken at
     // confirmation time for the safety threshold check (intentional — the
@@ -334,7 +350,7 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
 |---|---|
 | `CMakeLists.txt` | Use `ota_partitions.csv`; inject `VERSION` as `FIRMWARE_VERSION`; add new sources |
 | `cmake/BoardOptions.cmake` | Disable `HUGE_APP`, enable custom partition scheme |
-| `Weather_Station_2.cpp` | Add OTA check block; load assets via `AssetLoader` |
+| `Weather_Station_2.cpp` | Add OTA check block; load assets via `AssetLoader`; add `#include <inttypes.h>` for `PRIu64`; define `OTA_MANIFEST_URL` |
 | `src/display/KittyPics.h/.cpp` | Remove large PROGMEM arrays (replaced by SPIFFS files) |
 | `assets/fonts/Roboto_Light.h`, `Roboto_Medium.h` | Remove large PROGMEM font sizes (replaced by SPIFFS files) |
 

--- a/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
+++ b/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
@@ -1,0 +1,326 @@
+# OTA Firmware Update — Design Spec
+**Date:** 2026-04-13
+**Status:** Approved
+
+## Context
+
+The Weather Station 2 is a battery-powered ESP32/Inkplate 10 device that wakes every 10 minutes, fetches weather data, renders an e-paper display, then deep-sleeps. Currently the only way to update firmware is via USB/serial. This spec describes a WiFi-based OTA (Over-The-Air) update system that:
+
+- Checks for a new firmware version on each wakeup
+- Prompts the user to confirm before flashing
+- Verifies firmware authenticity before writing to flash
+- Is safe enough for a battery device (no brick risk from power loss)
+
+The firmware currently compiles to ~1.75MB. Asset externalization (Phase 0) shrinks this to ~1.25MB, giving comfortable headroom in dual-OTA partitions and reducing flash exposure from power loss during update.
+
+---
+
+## Architecture Overview
+
+**Infrastructure:**
+- **Manifest:** `GET /ota-firmware/data` on the local Pi json-store (HTTP, same pattern as `BatteryLogger`)
+- **Binary:** `GET /ota-firmware/binaries/firmware.bin` on the local Pi json-store (raw binary endpoint — see dependency note below)
+- **Signing:** ECDSA P-256; private key stays offline on developer machine, public key embedded in firmware
+- **Version source of truth:** A `VERSION` file in the repo root, read by both CMake (injected as `FIRMWARE_VERSION` at build time) and `ota_publish.py` (written into the manifest `version` field)
+
+**Dependency:** The json-store raw binary endpoint (`PUT/GET /:app/binaries/:id`) does not yet exist. This spec assumes it exists. A feature request will be filed with the json-store team once this spec is finalized.
+
+**Phasing (phase-sequential; each phase's spike(s) gate its implementation):**
+- Phase 0: PSRAM font spike → asset externalization to SPIFFS
+- Phase 1: Partition table spike → dual-OTA + SPIFFS layout (USB flash)
+- Phase 2: Python signing tooling (host-side, no hardware dependency; can run in parallel with Phases 0–1)
+- Phase 3: Streaming + ECDSA + OTA write spikes → `OTAManager` implementation
+
+---
+
+## Phase 0: Asset Externalization
+
+### Spike (must pass before any Phase 0 implementation)
+
+Write a 20-line test sketch that:
+1. Allocates a known font's bitmap data in PSRAM via `ps_malloc`
+2. Constructs a `GFXfont` struct pointing to that PSRAM buffer
+3. Calls `display.setFont()` and renders one character
+
+**Success criterion:** Character renders correctly on hardware.
+**If this spike fails:** Phase 0's design must be revisited before proceeding. Do not continue with asset externalization until this is resolved.
+
+### Goal
+
+Shrink the firmware binary from ~1.75MB to ~1.25MB by moving large fonts and cat images from PROGMEM into a SPIFFS partition, loaded at boot into PSRAM. On ESP32, `pgm_read_byte()` is a plain pointer dereference — PSRAM pointers work identically to PROGMEM pointers with Inkplate's rendering.
+
+### Assets to Externalize
+
+| Asset | ~Size | Approach |
+|---|---|---|
+| 6 cat images (3-bit packed, 300×300px) | ~270KB | Raw binary SPIFFS files; load via `ps_malloc` into PSRAM |
+| Roboto_Medium 150pt | ~80KB | Binary SPIFFS file; construct `GFXfont` from PSRAM buffer |
+| Roboto_Light 150pt | ~80KB | Same |
+| Roboto_Light 104pt | ~40KB | Same |
+| Smaller fonts (35pt and below) | ~30KB | Keep in PROGMEM — not worth the complexity |
+
+**Total savings:** ~470KB from firmware binary.
+
+### New Tooling: `tools/asset_packer.py`
+
+Converts PROGMEM C arrays in the font/image headers to flat binary files suitable for SPIFFS upload:
+
+```bash
+python3 tools/asset_packer.py --output assets/spiffs_image/
+```
+
+The SPIFFS image is flashed once via USB using esptool. OTA never touches the SPIFFS partition — assets stay put unless SPIFFS is deliberately reflashed.
+
+### New Module: `src/display/AssetLoader`
+
+Wraps SPIFFS open + `ps_malloc` + `GFXfont` construction. Called once per boot before rendering. Provides:
+- `uint8_t* loadImage(const char* path)` — loads raw image binary into PSRAM
+- `GFXfont* loadFont(const char* bitmapPath, const char* glyphPath, ...)` — loads font data into PSRAM, constructs and returns `GFXfont` struct
+
+---
+
+## Phase 1: Partition Table
+
+### Spike
+
+Flash `cmake/ota_partitions.csv` via USB, boot device, verify:
+- `esp_ota_get_next_update_partition()` returns non-NULL
+- `Serial.println(update_partition->label)` prints `"app1"`
+
+### Partition Layout (`cmake/ota_partitions.csv`)
+
+```
+nvs,      data, nvs,    0x9000,   0x5000
+otadata,  data, ota,    0xe000,   0x2000
+app0,     app,  ota_0,  0x10000,  0x140000   # 1.25MB
+app1,     app,  ota_1,  0x150000, 0x140000   # 1.25MB
+spiffs,   data, spiffs, 0x290000, 0x170000   # 1.4375MB for assets
+```
+
+- Each OTA partition: 1,310,720 bytes — comfortable for ~1.25MB firmware after Phase 0
+- SPIFFS: 1,474,560 bytes — fits all externalized assets (~470KB) with ~3× margin
+
+**Note:** The partition table change and Phase 0 asset externalization ship together in the same USB flash event. Both must be ready before this flash is performed.
+
+### Build System Changes
+
+**`CMakeLists.txt`:**
+- Replace `huge_app.csv` copy block with `ota_partitions.csv`
+- Read `VERSION` file and inject as `FIRMWARE_VERSION` compile-time define
+- Add `OTAManager.cpp`, `AssetLoader.cpp` to sources
+
+**`cmake/BoardOptions.cmake`:**
+- Disable `ARDUINO_INKPLATE_INKPLATE10_MENU_PARTITIONSCHEME_HUGE_APP`
+- Enable custom partition scheme
+
+---
+
+## Phase 2: Signing Tooling
+
+No hardware dependency. Can be developed in parallel with Phases 0 and 1.
+
+### Version Sync
+
+`VERSION` (repo root) is the single source of truth. Format: `YYYYMMDDNNN` (integer).
+
+- CMake reads `VERSION` and injects `FIRMWARE_VERSION` as a compile-time `#define`
+- `ota_publish.py` reads `VERSION` for the manifest `version` field
+- To cut a release: bump `VERSION`, build, run `ota_publish.py`
+- No manual constant to keep in sync
+
+See GitHub issue #10.
+
+### `tools/ota_keygen.py` (one-time)
+
+```bash
+python3 tools/ota_keygen.py --output-dir keys/
+# Produces: keys/ecdsa_private.pem  (gitignored, keep offline)
+#           keys/ecdsa_public.pem
+# Also writes: src/security/OTAPublicKey.h  (DER-encoded public key as const uint8_t[])
+```
+
+Depends on: `cryptography` Python package.
+
+### `tools/ota_publish.py`
+
+```bash
+python3 tools/ota_publish.py \
+  --firmware build/WeatherStation.bin \
+  --private-key keys/ecdsa_private.pem \
+  --pi-host 192.168.1.2:5000
+```
+
+Steps:
+1. Read `VERSION` file
+2. Read `.bin`, compute SHA-256
+3. Sign SHA-256 digest with ECDSA P-256 private key
+4. Base64-encode DER signature
+5. Write `manifest.json` locally
+6. `PUT` manifest to `http://<pi-host>/ota-firmware/data`
+7. `PUT` raw binary to `http://<pi-host>/ota-firmware/binaries/firmware.bin`
+
+### Manifest Format
+
+```json
+{
+  "version": 20260413001,
+  "size": 1234567,
+  "sha256": "a3f1d2...64 hex chars...",
+  "signature": "base64encodedDERsignature==",
+  "url": "http://192.168.1.2:5000/ota-firmware/binaries/firmware.bin",
+  "min_battery_mv": 3600
+}
+```
+
+| Field | Description |
+|---|---|
+| `version` | Integer build number from `VERSION` file; device compares `>` against compiled-in `FIRMWARE_VERSION` |
+| `size` | Exact byte count of `.bin` |
+| `sha256` | Hex SHA-256 of raw `.bin` |
+| `signature` | Base64 ECDSA P-256 signature over the SHA-256 digest bytes |
+| `url` | Direct HTTP link to raw binary on Pi json-store |
+| `min_battery_mv` | Device refuses OTA if battery is below this threshold |
+
+### Why ECDSA P-256
+
+- mbedTLS 2.x (shipped with ESP-IDF 4.x / Arduino ESP32) supports P-256 natively
+- Ed25519 requires mbedTLS 3.x — not available in this toolchain
+- HMAC-SHA256 requires embedding a secret key in firmware (symmetric = weaker)
+- RSA-2048 is 10–20× slower on ESP32 with large keys
+- P-256: 64-byte signature (DER-encoded ≈ 72 bytes), fast on ESP32
+
+---
+
+## Phase 3: OTAManager
+
+### Spikes (sequential; each must pass before the next)
+
+**Spike 1 — Streaming HTTP download:**
+Stream any HTTP binary from the Pi in 4KB chunks, accumulate SHA-256, log final hash. Success: hash matches expected; completes without OOM or timeout.
+
+**Spike 2 — ECDSA P-256 verify:**
+Generate known P-256 key pair in Python; sign a test digest; hardcode key + signature + digest in test sketch; call `mbedtls_ecdsa_verify()`. Success: returns 0 for valid sig, non-zero for tampered digest.
+
+**Spike 3 — OTA write:**
+Stream a test binary to `app1` via `esp_ota_begin/write/end`, set boot partition, restart. Success: `esp_ota_get_running_partition()->label` prints `"app1"`.
+
+### `OTAManager::checkForUpdate()`
+
+- `GET /ota-firmware/data` via plain HTTP (same pattern as `BatteryLogger`)
+- Parse with `ArduinoJson` (512-byte `StaticJsonDocument`)
+- Compare `version` field to compiled-in `FIRMWARE_VERSION`
+- Return `true` + populate `UpdateInfo` struct if manifest version is greater
+
+### `OTAManager::performUpdate()`
+
+- Stream binary from `info.url` in 4KB chunks via plain HTTP
+- Simultaneously: feed each chunk to SHA-256 accumulator + `esp_ota_write()`
+- After stream completes:
+  1. Verify computed SHA-256 matches manifest `sha256` field
+  2. Verify ECDSA P-256 signature over SHA-256 digest using `mbedtls_ecdsa_verify()` with embedded public key
+- Both pass: `esp_ota_set_boot_partition()` → `esp_restart()`
+- Either fails: `esp_ota_abort()` → return `false` (running partition untouched)
+
+### Integration in `Weather_Station_2.cpp`
+
+Insert after `network->begin()`, before weather fetch:
+
+```cpp
+OTAManager ota(network);
+OTAManager::UpdateInfo info;
+if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
+    // Render splash screen (e-paper refresh takes 2-4s — acceptable)
+    display.clearDisplay();
+    display.setFont(/* 35pt */);
+    display.setCursor(50, 350);
+    display.printf("Firmware v%llu available\nPress WAKE to install\n(30s to skip)", info.version);
+    display.printf("\nBattery: %.2fV", (display.readBattery() + ADC_OFFSET));
+    display.display();
+
+    // Poll GPIO 36 for 30s
+    unsigned long deadline = millis() + 30000;
+    bool confirmed = false;
+    while (millis() < deadline) {
+        if (digitalRead(36) == LOW) { confirmed = true; break; }
+        delay(100);
+    }
+
+    if (confirmed) {
+        float volts = display.readBattery() + ADC_OFFSET;
+        if ((int)(volts * 1000) < info.min_battery_mv) {
+            // Show "Battery too low", fall through to normal operation
+        } else {
+            display.clearDisplay();
+            display.print("Downloading firmware...\nDo not power off.");
+            display.display();
+            ota.performUpdate(info);
+            // esp_restart() called inside performUpdate on success
+            // On failure: fall through to normal weather display
+        }
+    }
+}
+```
+
+### Wake Button
+
+GPIO 36 (`WAKE_BUTTON_GPIO`) is already wired to the physical wake button. During the 30s confirmation window:
+- `pinMode(36, INPUT)` (input-only pin, hardware pull-up on Inkplate 10)
+- Poll `digitalRead(36) == LOW` in a 100ms loop
+
+### Spike 4 — Button GPIO poll (low risk)
+
+Short test: display message, poll `digitalRead(36)` for 10 seconds, print result to serial. Success: press reliably reads LOW; idle reads HIGH.
+
+---
+
+## Files to Create / Modify
+
+### New Files
+
+| File | Purpose |
+|---|---|
+| `VERSION` | Single source of truth for firmware version |
+| `cmake/ota_partitions.csv` | Dual-OTA + SPIFFS partition table |
+| `src/ota/OTAManager.h/.cpp` | OTA check + update logic |
+| `src/display/AssetLoader.h/.cpp` | SPIFFS + PSRAM asset loading |
+| `src/security/OTAPublicKey.h` | Embedded ECDSA P-256 public key |
+| `tools/ota_keygen.py` | One-time key pair generation + C header output |
+| `tools/ota_publish.py` | Sign firmware, write manifest, PUT to Pi json-store |
+| `tools/asset_packer.py` | Convert PROGMEM C arrays → flat binary files for SPIFFS |
+
+### Modified Files
+
+| File | Change |
+|---|---|
+| `CMakeLists.txt` | Use `ota_partitions.csv`; inject `VERSION` as `FIRMWARE_VERSION`; add new sources |
+| `cmake/BoardOptions.cmake` | Disable `HUGE_APP`, enable custom partition scheme |
+| `Weather_Station_2.cpp` | Add OTA check block; load assets via `AssetLoader` |
+| `src/display/KittyPics.h/.cpp` | Remove large PROGMEM arrays (replaced by SPIFFS files) |
+| `assets/fonts/Roboto_Light.h`, `Roboto_Medium.h` | Remove large PROGMEM font sizes (replaced by SPIFFS files) |
+
+---
+
+## Verification / Test Plan
+
+| Phase | Test | Success Criterion |
+|---|---|---|
+| Phase 0 spike | PSRAM font loading test sketch | Character renders correctly from PSRAM buffer |
+| Phase 0 integration | SPIFFS assets flashed, `AssetLoader` integrated, full weather cycle | Display renders correctly; firmware ~1.25MB |
+| Phase 1 spike | Flash `ota_partitions.csv` via USB, boot | `update_partition->label` prints `"app1"` |
+| Phase 2 | `ota_keygen.py` + `ota_publish.py` run on host | Manifest + binary published to Pi json-store; manifest parses correctly |
+| Phase 3 spike 1 | Streaming HTTP binary download | SHA-256 matches; no OOM or timeout |
+| Phase 3 spike 2 | ECDSA P-256 verify on hardware | Returns 0 for valid sig, non-zero for tampered digest |
+| Phase 3 spike 3 | OTA write test binary to `app1` | Boots from `app1` after restart |
+| Phase 3 spike 4 | GPIO 36 poll during active operation | Button press reads LOW reliably |
+| Phase 3 integration | End-to-end: publish → device detects → user confirms → flashes + restarts | Device boots updated firmware |
+| Negative tests | Tampered SHA-256; tampered signature; low battery | Each rejected correctly; old partition untouched |
+
+---
+
+## What's Deliberately Excluded
+
+- **Firmware encryption:** HTTP on the local network handles transport. AES encryption of the binary would require an AES key in the firmware, providing no real benefit.
+- **Rollback:** If the new firmware is bad, reflash via USB. Automatic rollback requires a health-check mechanism that's out of scope.
+- **Automatic install (no button):** Battery devices must never flash firmware unattended — power loss mid-flash bricks the device. The confirmation step is a safety requirement, not a UX choice.
+- **Public hosting (GitHub Releases):** Everything stays on the local Pi json-store. No CA cert complexity for the OTA path.
+- **json-store binary endpoint implementation:** Separate feature request to be filed with the json-store team.

--- a/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
+++ b/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
@@ -26,8 +26,8 @@ The firmware currently compiles to ~1.75MB. Asset externalization (Phase 0) shri
 **Dependency:** The json-store raw binary endpoint (`PUT/GET /:app/binaries/:id`) does not yet exist. This spec assumes it exists. A feature request will be filed with the json-store team once this spec is finalized.
 
 **Phasing (phase-sequential; each phase's spike(s) gate its implementation):**
-- Phase 0: PSRAM font spike → asset externalization to SPIFFS
-- Phase 1: Partition table spike → dual-OTA + SPIFFS layout (USB flash)
+- Phase 0: PSRAM font spike (independent) → if passes, implement `AssetLoader` and `asset_packer.py`; SPIFFS integration deferred until Phase 1 partition table is live
+- Phase 1: Partition table spike → dual-OTA + SPIFFS layout (USB flash, ships with Phase 0 SPIFFS image)
 - Phase 2: Python signing tooling (host-side, no hardware dependency; can run in parallel with Phases 0–1)
 - Phase 3: Streaming + ECDSA + OTA write spikes → `OTAManager` implementation
 
@@ -35,7 +35,7 @@ The firmware currently compiles to ~1.75MB. Asset externalization (Phase 0) shri
 
 ## Phase 0: Asset Externalization
 
-### Spike (must pass before any Phase 0 implementation)
+### Spike (independent — can run before Phase 1)
 
 Write a 20-line test sketch that:
 1. Allocates a known font's bitmap data in PSRAM via `ps_malloc`
@@ -44,6 +44,8 @@ Write a 20-line test sketch that:
 
 **Success criterion:** Character renders correctly on hardware.
 **If this spike fails:** Phase 0's design must be revisited before proceeding. Do not continue with asset externalization until this is resolved.
+
+This spike runs against the existing `huge_app` partition layout — no partition table change is required. If the spike passes, implement `AssetLoader` and `asset_packer.py`, and generate the SPIFFS image. Full SPIFFS integration (mounting SPIFFS, testing `AssetLoader` end-to-end) cannot be validated until the Phase 1 partition table is live on hardware.
 
 ### Goal
 
@@ -100,7 +102,9 @@ spiffs,   data, spiffs, 0x290000, 0x170000   # 1.4375MB for assets
 - Each OTA partition: 1,310,720 bytes — comfortable for ~1.25MB firmware after Phase 0
 - SPIFFS: 1,474,560 bytes — fits all externalized assets (~470KB) with ~3× margin
 
-**Note:** The partition table change and Phase 0 asset externalization ship together in the same USB flash event. Both must be ready before this flash is performed.
+**Note:** The partition table change, Phase 0 SPIFFS image, and updated firmware all ship together in the same USB flash event. The new SPIFFS partition does not exist until this flash is performed; `AssetLoader` end-to-end integration testing happens after this flash.
+
+**eeprom partition:** The current `huge_app` layout includes an `eeprom` partition at `0x310000` used by the Inkplate library for waveform storage (source of the boot warning "Waveform load failed! Upload new waveform in EEPROM"). The new layout drops the named `eeprom` partition. Before flashing, confirm whether the Inkplate library resolves EEPROM via the named partition or via ESP-IDF's NVS-backed EEPROM emulation. If it requires the named partition, add it back (at the cost of some SPIFFS space); if NVS-backed emulation suffices, the drop is safe. This must be resolved before the Phase 1 USB flash.
 
 ### Build System Changes
 
@@ -121,10 +125,15 @@ No hardware dependency. Can be developed in parallel with Phases 0 and 1.
 
 ### Version Sync
 
-`VERSION` (repo root) is the single source of truth. Format: `YYYYMMDDNNN` (integer).
+`VERSION` (repo root) is the single source of truth. Format: `YYYYMMDDNNN` (integer, one line, trailing newline).
 
-- CMake reads `VERSION` and injects `FIRMWARE_VERSION` as a compile-time `#define`
-- `ota_publish.py` reads `VERSION` for the manifest `version` field
+- CMake reads `VERSION` and injects `FIRMWARE_VERSION` as a compile-time `#define`. The newline must be stripped:
+  ```cmake
+  file(READ "${CMAKE_SOURCE_DIR}/VERSION" FIRMWARE_VERSION)
+  string(STRIP "${FIRMWARE_VERSION}" FIRMWARE_VERSION)
+  target_compile_definitions(WeatherStation PRIVATE FIRMWARE_VERSION=${FIRMWARE_VERSION})
+  ```
+- `ota_publish.py` reads `VERSION` automatically from the repo root (no `--version` CLI argument). The script locates `VERSION` relative to its own path.
 - To cut a release: bump `VERSION`, build, run `ota_publish.py`
 - No manual constant to keep in sync
 
@@ -207,19 +216,36 @@ Stream a test binary to `app1` via `esp_ota_begin/write/end`, set boot partition
 ### `OTAManager::checkForUpdate()`
 
 - `GET /ota-firmware/data` via plain HTTP (same pattern as `BatteryLogger`)
-- Parse with `ArduinoJson` (512-byte `StaticJsonDocument`)
+- Parse with `ArduinoJson` (`StaticJsonDocument<1024>` — the manifest contains a 64-char sha256, ~100-char base64 signature, and URL; 512 bytes is too tight once ArduinoJson tree overhead is included)
 - Compare `version` field to compiled-in `FIRMWARE_VERSION`
 - Return `true` + populate `UpdateInfo` struct if manifest version is greater
 
 ### `OTAManager::performUpdate()`
 
-- Stream binary from `info.url` in 4KB chunks via plain HTTP
-- Simultaneously: feed each chunk to SHA-256 accumulator + `esp_ota_write()`
-- After stream completes:
-  1. Verify computed SHA-256 matches manifest `sha256` field
-  2. Verify ECDSA P-256 signature over SHA-256 digest using `mbedtls_ecdsa_verify()` with embedded public key
-- Both pass: `esp_ota_set_boot_partition()` → `esp_restart()`
-- Either fails: `esp_ota_abort()` → return `false` (running partition untouched)
+Call sequence (order is critical for safe abort):
+
+1. `esp_ota_begin(update_partition, info.size, &handle)` — obtain handle
+2. For each 4KB chunk: `esp_ota_write(handle, chunk, len)` + SHA-256 accumulator update
+3. After stream: verify computed SHA-256 against manifest `sha256` field
+4. If SHA-256 passes: verify ECDSA P-256 signature over SHA-256 digest using `mbedtls_ecdsa_verify()` with embedded public key
+5. If both checks pass: `esp_ota_end(handle)` → `esp_ota_set_boot_partition()` → `esp_restart()`
+6. If either check fails: `esp_ota_abort(handle)` → return `false` (running partition untouched)
+
+**Important:** `esp_ota_end()` is called only after both SHA-256 and ECDSA checks pass. Calling `esp_ota_abort(handle)` before `esp_ota_end()` is always safe — it discards the incomplete write. Calling abort *after* `esp_ota_end()` is undefined; this ordering prevents that.
+
+### Wake Button
+
+GPIO 36 (`WAKE_BUTTON_GPIO`) is already wired to the physical wake button. During the 30s confirmation window:
+- `pinMode(36, INPUT)` (input-only pin, hardware pull-up on Inkplate 10)
+- Poll `digitalRead(36) == LOW` in a 100ms loop
+
+**WiFi during poll:** The WiFi connection stays active during the 30s window. If the connection to the Pi drops between the manifest fetch and the binary download, `performUpdate()` returns `false` and the device falls through to normal weather display — an acceptable failure mode.
+
+### Spike 4 — Button GPIO poll (low risk)
+
+Short test: display message, poll `digitalRead(36)` for 10 seconds, print result to serial. Success: press reliably reads LOW; idle reads HIGH.
+
+Run this spike before the full integration, even though it is low risk — confirms GPIO 36 behaviour during active (non-sleep) operation is as expected.
 
 ### Integration in `Weather_Station_2.cpp`
 
@@ -234,6 +260,9 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
     display.setFont(/* 35pt */);
     display.setCursor(50, 350);
     display.printf("Firmware v%llu available\nPress WAKE to install\n(30s to skip)", info.version);
+    // Battery shown on splash for user awareness; a second read is taken at
+    // confirmation time for the safety threshold check (intentional — the
+    // confirmation-time reading is what matters for flash safety).
     display.printf("\nBattery: %.2fV", (display.readBattery() + ADC_OFFSET));
     display.display();
 
@@ -246,30 +275,27 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
     }
 
     if (confirmed) {
-        float volts = display.readBattery() + ADC_OFFSET;
+        float volts = display.readBattery() + ADC_OFFSET;  // second read — safety threshold
         if ((int)(volts * 1000) < info.min_battery_mv) {
-            // Show "Battery too low", fall through to normal operation
+            display.clearDisplay();
+            display.print("Battery too low for update.\nConnect charger and try again.");
+            display.display();
+            // Fall through to normal operation
         } else {
             display.clearDisplay();
             display.print("Downloading firmware...\nDo not power off.");
             display.display();
-            ota.performUpdate(info);
-            // esp_restart() called inside performUpdate on success
-            // On failure: fall through to normal weather display
+            if (!ota.performUpdate(info)) {
+                display.clearDisplay();
+                display.print("Update failed.\nContinuing normal operation.");
+                display.display();
+                delay(3000);
+            }
+            // On success: esp_restart() was called inside performUpdate — never reaches here
         }
     }
 }
 ```
-
-### Wake Button
-
-GPIO 36 (`WAKE_BUTTON_GPIO`) is already wired to the physical wake button. During the 30s confirmation window:
-- `pinMode(36, INPUT)` (input-only pin, hardware pull-up on Inkplate 10)
-- Poll `digitalRead(36) == LOW` in a 100ms loop
-
-### Spike 4 — Button GPIO poll (low risk)
-
-Short test: display message, poll `digitalRead(36)` for 10 seconds, print result to serial. Success: press reliably reads LOW; idle reads HIGH.
 
 ---
 

--- a/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
+++ b/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
@@ -75,7 +75,7 @@ The SPIFFS image is flashed once via USB using esptool. OTA never touches the SP
 
 ### New Module: `src/display/AssetLoader`
 
-Wraps SPIFFS open + `ps_malloc` + `GFXfont` construction. Called once per boot before rendering. Provides:
+Wraps SPIFFS open + `ps_malloc` + `GFXfont` construction. Called once per boot before rendering. Must call `SPIFFS.begin()` (or require the caller to have done so) before any file operations — failure to mount SPIFFS produces a silent null return from `SPIFFS.open()`. Provides:
 - `uint8_t* loadImage(const char* path)` — loads raw image binary into PSRAM
 - `GFXfont* loadFont(const char* bitmapPath, const char* glyphPath, ...)` — loads font data into PSRAM, constructs and returns `GFXfont` struct
 
@@ -232,7 +232,7 @@ struct UpdateInfo {
 ### `OTAManager::checkForUpdate()`
 
 - `GET /ota-firmware/data` via plain HTTP (same pattern as `BatteryLogger`)
-- Parse with `ArduinoJson` (`StaticJsonDocument<1024>` — the manifest contains a 64-char sha256, ~100-char base64 signature, and URL; 512 bytes is too tight once ArduinoJson tree overhead is included)
+- Parse with `ArduinoJson` (`StaticJsonDocument<1024>` — raw content is ~250–300 bytes; ArduinoJson tree overhead for 6 fields adds ~288 bytes, totalling ~550–600 bytes worst case; 1024 gives safe headroom)
 - Compare `version` field to compiled-in `FIRMWARE_VERSION`
 - Return `true` + populate `UpdateInfo` struct if manifest version is greater
 
@@ -257,6 +257,8 @@ GPIO 36 (`WAKE_BUTTON_GPIO`) is already wired to the physical wake button. Durin
 
 **WiFi during poll:** The WiFi connection stays active during the 30s window. If the connection to the Pi drops between the manifest fetch and the binary download, `performUpdate()` returns `false` and the device falls through to normal weather display — an acceptable failure mode.
 
+**Button debounce:** The 100ms inter-poll interval is far longer than physical button bounce (microseconds), so a single LOW reading is a reliable press detection — no explicit debounce logic needed.
+
 ### Integration in `Weather_Station_2.cpp`
 
 Insert after `network->begin()`, before weather fetch:
@@ -269,7 +271,9 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
     display.clearDisplay();
     display.setFont(/* 35pt */);
     display.setCursor(50, 350);
-    display.printf("Firmware v%llu available\nPress WAKE to install\n(30s to skip)", info.version);
+    // %llu is broken on ESP32 Arduino (newlib-nano omits 64-bit printf).
+    // Use PRIu64 from <inttypes.h> or format the version separately.
+    display.printf("Firmware v%" PRIu64 " available\nPress WAKE to install\n(30s to skip)", info.version);
     // Battery shown on splash for user awareness; a second read is taken at
     // confirmation time for the safety threshold check (intentional — the
     // confirmation-time reading is what matters for flash safety).
@@ -348,7 +352,8 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
 | Phase 3 spike 2 | ECDSA P-256 verify on hardware | Returns 0 for valid sig, non-zero for tampered digest |
 | Phase 3 spike 3 | OTA write test binary to `app1` | Boots from `app1` after restart |
 | Phase 3 spike 4 | GPIO 36 poll during active operation | Button press reads LOW reliably |
-| Phase 3 integration | End-to-end: publish → device detects → user confirms → flashes + restarts | Device boots updated firmware |
+| Phase 3 integration — confirm path | End-to-end: publish → device detects → user presses button → flashes + restarts | Device boots updated firmware |
+| Phase 3 integration — skip path | Device detects update → user does not press button → 30s timeout elapses | Device falls through to normal weather display |
 | Negative tests | Tampered SHA-256; tampered signature; low battery | Each rejected correctly; old partition untouched |
 
 ---

--- a/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
+++ b/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
@@ -26,8 +26,8 @@ The firmware currently compiles to ~1.75MB. Asset externalization (Phase 0) shri
 **Dependency:** The json-store raw binary endpoint (`PUT/GET /:app/binaries/:id`) does not yet exist. This spec assumes it exists. A feature request will be filed with the json-store team once this spec is finalized.
 
 **Phasing (phase-sequential; each phase's spike(s) gate its implementation):**
-- Phase 0: PSRAM font spike (independent) → if passes, implement `AssetLoader` and `asset_packer.py`; SPIFFS integration deferred until Phase 1 partition table is live
-- Phase 1: Partition table spike → dual-OTA + SPIFFS layout (USB flash, ships with Phase 0 SPIFFS image)
+- Phase 0: PSRAM font spike (independent) → if passes, implement `AssetLoader` and `asset_packer.py`; LittleFS integration deferred until Phase 1 partition table is live
+- Phase 1: Partition table spike → dual-OTA + LittleFS layout (USB flash, ships with Phase 0 LittleFS image)
 - Phase 2: Python signing tooling (host-side, no hardware dependency; can run in parallel with Phases 0–1)
 - Phase 3: Streaming + ECDSA + OTA write spikes → `OTAManager` implementation
 
@@ -45,18 +45,18 @@ Write a 20-line test sketch that:
 **Success criterion:** Character renders correctly on hardware.
 **If this spike fails:** Phase 0's design must be revisited before proceeding. Do not continue with asset externalization until this is resolved.
 
-This spike runs against the existing `huge_app` partition layout — no partition table change is required. If the spike passes, implement `AssetLoader` and `asset_packer.py`, and generate the SPIFFS image. Full SPIFFS integration (mounting SPIFFS, testing `AssetLoader` end-to-end) cannot be validated until the Phase 1 partition table is live on hardware.
+This spike runs against the existing `huge_app` partition layout — no partition table change is required. If the spike passes, implement `AssetLoader` and `asset_packer.py`, and generate the LittleFS image. Full LittleFS integration (mounting LittleFS, testing `AssetLoader` end-to-end) cannot be validated until the Phase 1 partition table is live on hardware.
 
 ### Goal
 
-Shrink the firmware binary from ~1.75MB to ~1.25MB by moving large fonts and cat images from PROGMEM into a SPIFFS partition, loaded at boot into PSRAM. On ESP32, `pgm_read_byte()` is a plain pointer dereference — PSRAM pointers work identically to PROGMEM pointers with Inkplate's rendering.
+Shrink the firmware binary from ~1.75MB to ~1.25MB by moving large fonts and cat images from PROGMEM into a LittleFS partition, loaded at boot into PSRAM. LittleFS is used in preference to SPIFFS — SPIFFS is deprecated in the Arduino ESP32 core (as of 2.x); LittleFS is actively maintained, power-loss resilient by design, and uses the same partition subtype (`spiffs`, 0x82) in the partition table, so no layout difference exists. On ESP32, `pgm_read_byte()` is a plain pointer dereference — PSRAM pointers work identically to PROGMEM pointers with Inkplate's rendering.
 
 ### Assets to Externalize
 
 | Asset | ~Size | Approach |
 |---|---|---|
-| 6 cat images (3-bit packed, 300×300px) | ~270KB | Raw binary SPIFFS files; load via `ps_malloc` into PSRAM |
-| Roboto_Medium 150pt | ~80KB | Binary SPIFFS file; construct `GFXfont` from PSRAM buffer |
+| 6 cat images (3-bit packed, 300×300px) | ~270KB | Raw binary LittleFS files; load via `ps_malloc` into PSRAM |
+| Roboto_Medium 150pt | ~80KB | Binary LittleFS file; construct `GFXfont` from PSRAM buffer |
 | Roboto_Light 150pt | ~80KB | Same |
 | Roboto_Light 104pt | ~40KB | Same |
 | Smaller fonts (35pt and below) | ~30KB | Keep in PROGMEM — not worth the complexity |
@@ -65,17 +65,17 @@ Shrink the firmware binary from ~1.75MB to ~1.25MB by moving large fonts and cat
 
 ### New Tooling: `tools/asset_packer.py`
 
-Converts PROGMEM C arrays in the font/image headers to flat binary files suitable for SPIFFS upload:
+Converts PROGMEM C arrays in the font/image headers to flat binary files suitable for LittleFS upload:
 
 ```bash
-python3 tools/asset_packer.py --output assets/spiffs_image/
+python3 tools/asset_packer.py --output assets/littlefs_image/
 ```
 
-The SPIFFS image is flashed once via USB using esptool. OTA never touches the SPIFFS partition — assets stay put unless SPIFFS is deliberately reflashed.
+The LittleFS image is created with `mklittlefs` and flashed once via USB using esptool. OTA never touches the LittleFS partition — assets stay put unless deliberately reflashed via USB.
 
 ### New Module: `src/display/AssetLoader`
 
-Wraps SPIFFS open + `ps_malloc` + `GFXfont` construction. Called once per boot before rendering. `AssetLoader` calls `SPIFFS.begin()` internally before any file operations — it does not require the caller to do so. Failure to mount SPIFFS produces a silent null return from `SPIFFS.open()`, so `AssetLoader` must check the return value and log/assert on failure. Provides:
+Wraps LittleFS open + `ps_malloc` + `GFXfont` construction. Called once per boot before rendering. `AssetLoader` calls `LittleFS.begin()` internally before any file operations — it does not require the caller to do so. Failure to mount LittleFS produces a silent null return from `LittleFS.open()`, so `AssetLoader` must check the return value and log/assert on failure. Provides:
 - `uint8_t* loadImage(const char* path)` — loads raw image binary into PSRAM
 - `GFXfont* loadFont(const char* bitmapPath, const char* glyphPath, ...)` — loads font data into PSRAM, constructs and returns `GFXfont` struct
 
@@ -100,11 +100,12 @@ spiffs,   data, spiffs, 0x290000, 0x170000   # 1.4375MB for assets
 ```
 
 - Each OTA partition: 1,310,720 bytes — comfortable for ~1.25MB firmware after Phase 0
-- SPIFFS: 1,474,560 bytes — fits all externalized assets (~470KB) with ~3× margin
+- LittleFS: 1,474,560 bytes — fits all externalized assets (~470KB) with ~3× margin
+- Partition subtype is `spiffs` (0x82) — this is the ESP-IDF partition subtype used by both SPIFFS and LittleFS; the filesystem choice is made at mount time, not in the partition table
 
-**Note:** The partition table change, Phase 0 SPIFFS image, and updated firmware all ship together in the same USB flash event. The new SPIFFS partition does not exist until this flash is performed; `AssetLoader` end-to-end integration testing happens after this flash.
+**Note:** The partition table change, Phase 0 LittleFS image, and updated firmware all ship together in the same USB flash event. The new partition does not exist until this flash is performed; `AssetLoader` end-to-end integration testing happens after this flash.
 
-**eeprom partition:** The current `huge_app` layout includes an `eeprom` partition at `0x310000` used by the Inkplate library for waveform storage (source of the boot warning "Waveform load failed! Upload new waveform in EEPROM"). The new layout drops the named `eeprom` partition. Before flashing, confirm whether the Inkplate library resolves EEPROM via the named partition or via ESP-IDF's NVS-backed EEPROM emulation. If it requires the named partition, add it back (at the cost of some SPIFFS space); if NVS-backed emulation suffices, the drop is safe. This must be resolved before the Phase 1 USB flash.
+**eeprom partition (must be resolved before starting Phase 1 work):** The current `huge_app` layout includes an `eeprom` partition at `0x310000` used by the Inkplate library for waveform storage (source of the boot warning "Waveform load failed! Upload new waveform in EEPROM"). The new layout drops the named `eeprom` partition. Investigate whether the Inkplate library requires the named partition or uses ESP-IDF's NVS-backed EEPROM emulation before writing any Phase 1 code. If it requires the named partition, add it back (at the cost of some LittleFS space). Do not defer this to flash time — it needs to be resolved during Phase 1 design so the partition table is correct before anyone touches a USB cable.
 
 ### Build System Changes
 
@@ -244,10 +245,22 @@ struct UpdateInfo {
 static const uint64_t COMPILED_VERSION = FIRMWARE_VERSION;
 ```
 
+### Manifest Security / Threat Model
+
+The manifest is fetched over plain HTTP on the local network. The firmware binary is protected by ECDSA P-256 signature — an attacker who tampers with the manifest cannot cause the device to flash arbitrary code because the signature check will reject any binary not signed with the private key.
+
+**Residual risks on a compromised local network:**
+- `min_battery_mv` lowered → device attempts OTA at critically low battery → potential brick during flash. This is the most meaningful risk.
+- `version` inflated → device attempts OTA on every wakeup → battery drain.
+- `url` redirected to a valid old signed binary → download + ECDSA check passes, but version check prevents a downgrade (old `version` < `FIRMWARE_VERSION`).
+
+**Decision:** Accept the local network trust model. This is a home device on a private network; the attack requires local network access. The firmware binary itself is strongly authenticated. If the threat model changes (e.g., device moved to a less trusted network), the mitigation is to sign the manifest JSON with the same ECDSA key pair and verify it on device before trusting any manifest field — this is a future enhancement, not part of this spec. HMAC is explicitly not recommended (symmetric key in firmware has the same weakness already rejected for firmware encryption).
+
 ### `OTAManager::checkForUpdate(const char* manifestUrl, UpdateInfo& info)`
 
 - `GET manifestUrl` via plain HTTP (same pattern as `BatteryLogger`)
 - Parse with `ArduinoJson` (`StaticJsonDocument<1024>` — raw content is ~250–300 bytes; ArduinoJson tree overhead for 6 fields adds ~288 bytes, totalling ~550–600 bytes worst case; 1024 gives safe headroom)
+- **Validate all required fields** before populating `info`. ArduinoJson silently returns 0 for missing integers and empty string for missing strings — a missing `url` flowing into `performUpdate()` is a bug. If any of `version`, `sha256`, `signature`, `url`, `min_battery_mv` is missing or empty, log a debug message and return `false` (treat as no update available).
 - Compare `version` field to compiled-in `FIRMWARE_VERSION`
 - Return `true` + populate `info` struct if manifest version is greater
 
@@ -265,6 +278,8 @@ Call sequence (order is critical for safe abort):
 6. If either check fails: `esp_ota_abort(handle)` → return `false` (running partition untouched)
 
 **HTTP timeout:** Set `HTTPClient::setTimeout()` to a reasonable value (e.g., 30s) before beginning the stream. On a local network the Pi is unlikely to disappear mid-stream, but without a timeout the device will hang indefinitely with WiFi active if the connection drops.
+
+**Progress display:** The download screen should show progress using `info.size`. After `esp_ota_begin()`, update the display with bytes written vs `info.size` periodically (e.g., every 64KB). This gives the user feedback during a potentially 30–60 second download and makes a mid-stream WiFi dropout distinguishable from normal operation.
 
 **Important:** `esp_ota_end()` is called only after both SHA-256 and ECDSA checks pass. Calling `esp_ota_abort(handle)` before `esp_ota_end()` is always safe — it discards the incomplete write. Calling abort *after* `esp_ota_end()` is undefined; this ordering prevents that.
 
@@ -344,11 +359,11 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
 | `VERSION` | Single source of truth for firmware version |
 | `cmake/ota_partitions.csv` | Dual-OTA + SPIFFS partition table |
 | `src/ota/OTAManager.h/.cpp` | OTA check + update logic |
-| `src/display/AssetLoader.h/.cpp` | SPIFFS + PSRAM asset loading |
+| `src/display/AssetLoader.h/.cpp` | LittleFS + PSRAM asset loading |
 | `src/security/OTAPublicKey.h` | Embedded ECDSA P-256 public key |
 | `tools/ota_keygen.py` | One-time key pair generation + C header output |
 | `tools/ota_publish.py` | Sign firmware, write manifest, PUT to Pi json-store |
-| `tools/asset_packer.py` | Convert PROGMEM C arrays → flat binary files for SPIFFS |
+| `tools/asset_packer.py` | Convert PROGMEM C arrays → flat binary files for LittleFS |
 
 ### Modified Files
 
@@ -357,8 +372,8 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
 | `CMakeLists.txt` | Use `ota_partitions.csv`; inject `VERSION` as `FIRMWARE_VERSION`; add new sources |
 | `cmake/BoardOptions.cmake` | Disable `HUGE_APP`, enable custom partition scheme |
 | `Weather_Station_2.cpp` | Add OTA check block; load assets via `AssetLoader`; add `#include <inttypes.h>` for `PRIu64`; define `OTA_MANIFEST_URL` |
-| `src/display/KittyPics.h/.cpp` | Remove large PROGMEM arrays (replaced by SPIFFS files) |
-| `assets/fonts/Roboto_Light.h`, `Roboto_Medium.h` | Remove large PROGMEM font sizes (replaced by SPIFFS files) |
+| `src/display/KittyPics.h/.cpp` | Remove large PROGMEM arrays (replaced by LittleFS files) |
+| `assets/fonts/Roboto_Light.h`, `Roboto_Medium.h` | Remove large PROGMEM font sizes (replaced by LittleFS files) |
 
 ---
 
@@ -367,7 +382,7 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
 | Phase | Test | Success Criterion |
 |---|---|---|
 | Phase 0 spike | PSRAM font loading test sketch | Character renders correctly from PSRAM buffer |
-| Phase 0 integration | SPIFFS assets flashed, `AssetLoader` integrated, full weather cycle | Display renders correctly; firmware ~1.25MB |
+| Phase 0 integration | LittleFS assets flashed, `AssetLoader` integrated, full weather cycle | Display renders correctly; firmware ~1.25MB |
 | Phase 1 spike | Flash `ota_partitions.csv` via USB, boot | `update_partition->label` prints `"app1"` |
 | Phase 2 | `ota_keygen.py` + `ota_publish.py` run on host | Manifest + binary published to Pi json-store; manifest parses correctly |
 | Phase 3 spike 1 | Streaming HTTP binary download | SHA-256 matches; no OOM or timeout |
@@ -376,7 +391,7 @@ if (ota.checkForUpdate(OTA_MANIFEST_URL, info)) {
 | Phase 3 spike 4 | GPIO 36 poll during active operation | Button press reads LOW reliably |
 | Phase 3 integration — confirm path | End-to-end: publish → device detects → user presses button → flashes + restarts | Device boots updated firmware |
 | Phase 3 integration — skip path | Device detects update → user does not press button → 30s timeout elapses | Device falls through to normal weather display |
-| Negative tests | Tampered SHA-256; tampered signature; low battery | Each rejected correctly; old partition untouched |
+| Negative tests | Tampered SHA-256; tampered signature; low battery; missing manifest field | Each rejected correctly; old partition untouched |
 
 ---
 

--- a/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
+++ b/docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md
@@ -187,7 +187,7 @@ Steps:
 | `size` | Exact byte count of `.bin` |
 | `sha256` | Hex SHA-256 of raw `.bin` |
 | `signature` | Base64 ECDSA P-256 signature over the SHA-256 digest bytes |
-| `url` | Direct HTTP link to raw binary on Pi json-store |
+| `url` | Direct HTTP link to raw binary on Pi json-store. The Pi IP is embedded in the manifest by `ota_publish.py` via `--pi-host`. If the Pi's IP changes, re-running `ota_publish.py` generates an updated manifest with the new URL — intentional for a controlled local network environment. |
 | `min_battery_mv` | Device refuses OTA if battery is below this threshold |
 
 ### Why ECDSA P-256
@@ -202,7 +202,7 @@ Steps:
 
 ## Phase 3: OTAManager
 
-### Spikes (sequential; each must pass before the next)
+### Spikes (run in order; each must pass before the next)
 
 **Spike 1 — Streaming HTTP download:**
 Stream any HTTP binary from the Pi in 4KB chunks, accumulate SHA-256, log final hash. Success: hash matches expected; completes without OOM or timeout.
@@ -212,6 +212,22 @@ Generate known P-256 key pair in Python; sign a test digest; hardcode key + sign
 
 **Spike 3 — OTA write:**
 Stream a test binary to `app1` via `esp_ota_begin/write/end`, set boot partition, restart. Success: `esp_ota_get_running_partition()->label` prints `"app1"`.
+
+**Spike 4 — Button GPIO poll (low risk):**
+Display a message, poll `digitalRead(36)` for 10 seconds, print result to serial. Success: press reliably reads LOW; idle reads HIGH. Confirms GPIO 36 behaviour during active (non-sleep) operation matches the deep-sleep wakeup configuration.
+
+### `UpdateInfo` Struct
+
+```cpp
+struct UpdateInfo {
+    uint64_t version;       // YYYYMMDDNNN — exceeds uint32_t max, must be 64-bit
+    uint32_t size;          // exact byte count from manifest (informational only; not passed to esp_ota_begin)
+    char sha256[65];        // 64 hex chars + null terminator
+    char signature[200];    // base64 DER ECDSA signature (~100 chars; 200 gives headroom)
+    char url[128];          // URL to raw binary on Pi json-store
+    int min_battery_mv;     // minimum battery in millivolts to proceed
+};
+```
 
 ### `OTAManager::checkForUpdate()`
 
@@ -224,7 +240,7 @@ Stream a test binary to `app1` via `esp_ota_begin/write/end`, set boot partition
 
 Call sequence (order is critical for safe abort):
 
-1. `esp_ota_begin(update_partition, info.size, &handle)` — obtain handle
+1. `esp_ota_begin(update_partition, OTA_SIZE_UNKNOWN, &handle)` — obtain handle. `OTA_SIZE_UNKNOWN` is used because the manifest `size` field is not covered by the ECDSA signature (which signs only the binary's SHA-256 digest, not the manifest JSON). On a plain HTTP channel, passing an attacker-controlled `size` to `esp_ota_begin()` is unsafe. Content length is validated implicitly when the SHA-256 over the streamed bytes matches the manifest's `sha256` field.
 2. For each 4KB chunk: `esp_ota_write(handle, chunk, len)` + SHA-256 accumulator update
 3. After stream: verify computed SHA-256 against manifest `sha256` field
 4. If SHA-256 passes: verify ECDSA P-256 signature over SHA-256 digest using `mbedtls_ecdsa_verify()` with embedded public key
@@ -240,12 +256,6 @@ GPIO 36 (`WAKE_BUTTON_GPIO`) is already wired to the physical wake button. Durin
 - Poll `digitalRead(36) == LOW` in a 100ms loop
 
 **WiFi during poll:** The WiFi connection stays active during the 30s window. If the connection to the Pi drops between the manifest fetch and the binary download, `performUpdate()` returns `false` and the device falls through to normal weather display — an acceptable failure mode.
-
-### Spike 4 — Button GPIO poll (low risk)
-
-Short test: display message, poll `digitalRead(36)` for 10 seconds, print result to serial. Success: press reliably reads LOW; idle reads HIGH.
-
-Run this spike before the full integration, even though it is low risk — confirms GPIO 36 behaviour during active (non-sleep) operation is as expected.
 
 ### Integration in `Weather_Station_2.cpp`
 


### PR DESCRIPTION
## Summary

- Brainstormed and validated OTA firmware update design for the Inkplate 10
- Supersedes the earlier draft at `docs/DESIGN-ota-firmware-update.md`
- Went through 5 automated spec review iterations before approval

## Key decisions captured

- Manifest + binary both hosted on local Pi json-store (HTTP, not GitHub)
- `VERSION` file as single source of truth for firmware version sync (issue #10)
- Phase-sequential execution with spikes gating each phase
- Phase 0 asset externalization (SPIFFS + PSRAM) explicitly in scope
- ECDSA P-256 signing; `Prehashed()` contract between Python and mbedTLS
- `OTA_SIZE_UNKNOWN` in `esp_ota_begin()` — content validated by SHA-256 + ECDSA
- ESP-IDF native OTA API (`esp_ota_ops.h`), not Arduino `Update` library
- json-store binary endpoint assumed to exist (separate feature request)

## Spec location

`docs/superpowers/specs/2026-04-13-ota-firmware-update-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)