### PR TITLE
feat: move hardcoded config values to git-ignored config.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ compile_commands.json
 Inkplate-Arduino-library/
 .private-journal/
 .worktrees/
+config.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,9 @@ add_executable(WeatherStation
     src/security/CACerts.cpp
 )
 
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/generated)
-configure_file(src/config.h.in ${CMAKE_BINARY_DIR}/generated/config.h)
-target_include_directories(WeatherStation PRIVATE src ${CMAKE_BINARY_DIR})
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/generated/weather_station_2)
+configure_file(src/user_settings.h.in ${CMAKE_BINARY_DIR}/generated/weather_station_2/user_settings.h)
+target_include_directories(WeatherStation PRIVATE src ${CMAKE_BINARY_DIR}/generated)
 
 # LCBUrl declares architectures=avr,esp32 but this platform identifies as arch "Inkplate".
 # Set path explicitly to bypass arduino-cmake-toolchain's architecture filter.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@
 cmake_minimum_required(VERSION 3.16)
 project(WeatherStation CXX)
 
+if(NOT EXISTS "${CMAKE_SOURCE_DIR}/config.cmake")
+    message(FATAL_ERROR "config.cmake not found. Copy config.cmake.example to config.cmake and fill in your values.")
+endif()
+include(${CMAKE_SOURCE_DIR}/config.cmake)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # ── Firmware target ───────────────────────────────────────────────────────────
@@ -18,7 +23,8 @@ add_executable(WeatherStation
     src/security/CACerts.cpp
 )
 
-target_include_directories(WeatherStation PRIVATE src)
+configure_file(src/config.h.in ${CMAKE_BINARY_DIR}/generated/config.h)
+target_include_directories(WeatherStation PRIVATE src ${CMAKE_BINARY_DIR}/generated)
 
 # LCBUrl declares architectures=avr,esp32 but this platform identifies as arch "Inkplate".
 # Set path explicitly to bypass arduino-cmake-toolchain's architecture filter.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ add_executable(WeatherStation
 
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/generated)
 configure_file(src/config.h.in ${CMAKE_BINARY_DIR}/generated/config.h)
-target_include_directories(WeatherStation PRIVATE src ${CMAKE_BINARY_DIR}/generated)
+target_include_directories(WeatherStation PRIVATE src ${CMAKE_BINARY_DIR})
 
 # LCBUrl declares architectures=avr,esp32 but this platform identifies as arch "Inkplate".
 # Set path explicitly to bypass arduino-cmake-toolchain's architecture filter.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(WeatherStation
     src/security/CACerts.cpp
 )
 
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/generated)
 configure_file(src/config.h.in ${CMAKE_BINARY_DIR}/generated/config.h)
 target_include_directories(WeatherStation PRIVATE src ${CMAKE_BINARY_DIR}/generated)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(WeatherStation CXX)
 if(NOT EXISTS "${CMAKE_SOURCE_DIR}/config.cmake")
     message(FATAL_ERROR "config.cmake not found. Copy config.cmake.example to config.cmake and fill in your values.")
 endif()
-include(${CMAKE_SOURCE_DIR}/config.cmake)
+include("${CMAKE_SOURCE_DIR}/config.cmake")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/Weather_Station_2.cpp
+++ b/Weather_Station_2.cpp
@@ -21,7 +21,7 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 #error "Wrong board selection for this example, please select Inkplate 10 in the boards menu."
 #endif
 
-#include "generated/config.h"
+#include "weather_station_2/user_settings.h"
 #include "src/security/CACerts.h"
 #include "src/network/CurrentConditions.h"
 #include "src/display/DisplayLocations.h"

--- a/Weather_Station_2.cpp
+++ b/Weather_Station_2.cpp
@@ -21,6 +21,7 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 #error "Wrong board selection for this example, please select Inkplate 10 in the boards menu."
 #endif
 
+#include "generated/config.h"
 #include "src/security/CACerts.h"
 #include "src/network/CurrentConditions.h"
 #include "src/display/DisplayLocations.h"
@@ -41,7 +42,7 @@ char buffer[256];
 
 void setup() {
     float ADC_OFFSET = -0.50;
-    auto network = std::make_shared<Network>("NorwegianFish", "rufalina");
+    auto network = std::make_shared<Network>(WIFI_SSID, WIFI_PASSWORD);
     rtc_get_reset_reason(0);
     DisplayLocation kitties(850, 50, 300, 300);
     Serial.begin(115200);
@@ -61,7 +62,7 @@ void setup() {
 
     network->begin();
 
-    CurrentConditions curr(network);
+    CurrentConditions curr(network, WEATHER_STATION_ID);
 
     const uint8_t* nextKitty = Kitties::getNextKitty();
 
@@ -218,7 +219,7 @@ void setup() {
     // Log battery reading for discharge curve calibration
     time_t now;
     time(&now);
-    BatteryLogger batteryLogger("http://192.168.1.2:5000/weather-station/documents/battery-log");
+    BatteryLogger batteryLogger(BATTERY_LOGGER_URL);
     batteryLogger.log(now, rawBattery, voltage);
 
     // Goto deep sleep

--- a/config.cmake.example
+++ b/config.cmake.example
@@ -1,5 +1,5 @@
 # ABOUTME: Example configuration file for Weather Station.
-# ABOUTME: Copy to config.cmake, fill in real values, and never commit config.cmake.
+# ABOUTME: Placeholder values to be replaced with real credentials before building.
 set(WIFI_SSID "your-ssid-here")
 set(WIFI_PASSWORD "your-password-here")
 set(WEATHER_STATION_ID "XXXX")

--- a/config.cmake.example
+++ b/config.cmake.example
@@ -1,0 +1,6 @@
+# ABOUTME: Example configuration file for Weather Station.
+# ABOUTME: Copy to config.cmake, fill in real values, and never commit config.cmake.
+set(WIFI_SSID "your-ssid-here")
+set(WIFI_PASSWORD "your-password-here")
+set(WEATHER_STATION_ID "XXXX")
+set(BATTERY_LOGGER_URL "http://your-server/path")

--- a/docs/superpowers/plans/2026-04-15-config-extraction.md
+++ b/docs/superpowers/plans/2026-04-15-config-extraction.md
@@ -1,0 +1,273 @@
+# Config Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move hardcoded WiFi credentials, weather station ID, and battery logger URL out of source files into a git-ignored `config.cmake`, with CMake generating `${CMAKE_BINARY_DIR}/generated/config.h` for use by the firmware.
+
+**Architecture:** A `config.cmake` file (git-ignored) holds local environment values as CMake variables. `CMakeLists.txt` includes it with a `FATAL_ERROR` guard, then calls `configure_file` to substitute those variables into `src/config.h.in`, producing `${CMAKE_BINARY_DIR}/generated/config.h`. Source files `#include "config.h"` directly.
+
+**Tech Stack:** CMake `configure_file`, C++11 `#define` macros, arduino-cmake-toolchain, ESP32/Inkplate 10.
+
+**Spec:** `docs/superpowers/specs/2026-04-15-config-extraction-design.md`
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `config.cmake.example` | Committed template with placeholder values — the only onboarding reference |
+| Create (git-ignored) | `config.cmake` | Local environment values; never committed |
+| Create | `src/config.h.in` | CMake template; `@VAR@` tokens substituted at configure time |
+| Modify | `CMakeLists.txt` | Include guard, `configure_file`, extended `target_include_directories` |
+| Modify | `.gitignore` | Exclude `config.cmake` |
+| Modify | `Weather_Station_2.cpp` | Consume `WIFI_SSID`, `WIFI_PASSWORD`, `WEATHER_STATION_ID`, `BATTERY_LOGGER_URL` from `config.h` |
+| Modify | `CurrentConditions.h` | Remove `= "KBFI"` default; station now always passed explicitly |
+| No change | `CurrentConditions.cpp` | Station used only via `m_station` set in constructor — unaffected |
+
+---
+
+## Chunk 1: Config files and .gitignore
+
+### Task 1: Create `config.cmake.example`
+
+**Files:**
+- Create: `config.cmake.example`
+
+- [ ] **Step 1: Create the example file**
+
+```cmake
+# ABOUTME: Example configuration file for Weather Station.
+# ABOUTME: Copy to config.cmake, fill in real values, and never commit config.cmake.
+set(WIFI_SSID "your-ssid-here")
+set(WIFI_PASSWORD "your-password-here")
+set(WEATHER_STATION_ID "XXXX")
+set(BATTERY_LOGGER_URL "http://your-server/path")
+```
+
+- [ ] **Step 2: Create your local `config.cmake`**
+
+Copy `config.cmake.example` to `config.cmake` and substitute the real values currently hardcoded in:
+- `Weather_Station_2.cpp:44` — `WIFI_SSID` and `WIFI_PASSWORD`
+- `CurrentConditions.h:24` — `WEATHER_STATION_ID` (default value `"KBFI"`)
+- `Weather_Station_2.cpp:221` — `BATTERY_LOGGER_URL`
+
+```bash
+cp config.cmake.example config.cmake
+# edit config.cmake with real values
+```
+
+- [ ] **Step 3: Add `config.cmake` to `.gitignore`**
+
+In `.gitignore`, add a line after the existing entries:
+
+```
+config.cmake
+```
+
+- [ ] **Step 4: Verify `config.cmake` is ignored**
+
+```bash
+git status
+```
+
+Expected: `config.cmake` does **not** appear in untracked files. `config.cmake.example` and `.gitignore` do appear as modified/untracked.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add config.cmake.example .gitignore
+git commit -m "feat: add config.cmake.example and gitignore entry for issue #10"
+```
+
+---
+
+## Chunk 2: CMake wiring
+
+### Task 2: Create `src/config.h.in` and wire `CMakeLists.txt`
+
+**Files:**
+- Create: `src/config.h.in`
+- Modify: `CMakeLists.txt`
+
+- [ ] **Step 1: Create `src/config.h.in`**
+
+```c
+// ABOUTME: CMake-generated header providing compile-time configuration values.
+// ABOUTME: Values are substituted by CMake at configure time from config.cmake.
+#ifndef CONFIG_H
+#define CONFIG_H
+#define WIFI_SSID "@WIFI_SSID@"
+#define WIFI_PASSWORD "@WIFI_PASSWORD@"
+#define WEATHER_STATION_ID "@WEATHER_STATION_ID@"
+#define BATTERY_LOGGER_URL "@BATTERY_LOGGER_URL@"
+#endif  // CONFIG_H
+```
+
+- [ ] **Step 2: Add the `config.cmake` guard and include to `CMakeLists.txt`**
+
+Insert these lines after `project(WeatherStation CXX)` (line 5) and before `set(CMAKE_EXPORT_COMPILE_COMMANDS ON)` (line 7):
+
+```cmake
+if(NOT EXISTS "${CMAKE_SOURCE_DIR}/config.cmake")
+    message(FATAL_ERROR "config.cmake not found. Copy config.cmake.example to config.cmake and fill in your values.")
+endif()
+include(${CMAKE_SOURCE_DIR}/config.cmake)
+```
+
+- [ ] **Step 3: Add `configure_file` and update `target_include_directories` in `CMakeLists.txt`**
+
+After the `add_executable(WeatherStation ...)` block, add `configure_file` immediately before the existing `target_include_directories` line, then **replace** that existing line with the expanded form.
+
+Replace:
+```cmake
+target_include_directories(WeatherStation PRIVATE src)
+```
+
+With:
+```cmake
+configure_file(src/config.h.in ${CMAKE_BINARY_DIR}/generated/config.h)
+target_include_directories(WeatherStation PRIVATE src ${CMAKE_BINARY_DIR}/generated)
+```
+
+- [ ] **Step 4: Verify configure fails without `config.cmake`**
+
+Clear the build directory and temporarily rename `config.cmake`, then run configure:
+
+```bash
+rm -rf build
+mv config.cmake config.cmake.bak
+cmake \
+  -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake \
+  -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake \
+  -B build \
+  -G Ninja
+```
+
+Expected: CMake exits with:
+```
+CMake Error at CMakeLists.txt:X (message):
+  config.cmake not found. Copy config.cmake.example to config.cmake and fill in your values.
+```
+
+Restore:
+```bash
+mv config.cmake.bak config.cmake
+```
+
+- [ ] **Step 5: Verify configure succeeds and generated header is correct**
+
+```bash
+cmake \
+  -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake \
+  -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake \
+  -B build \
+  -G Ninja
+```
+
+Expected: Configure completes without errors.
+
+```bash
+cat build/generated/config.h
+```
+
+Expected: All four `#define` lines show your real values (not `@VAR@` tokens).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/config.h.in CMakeLists.txt
+git commit -m "feat: wire CMake configure_file for config.h generation (issue #10)"
+```
+
+---
+
+## Chunk 3: Source file updates
+
+### Task 3: Update `Weather_Station_2.cpp` and `CurrentConditions.h`
+
+**Files:**
+- Modify: `Weather_Station_2.cpp`
+- Modify: `CurrentConditions.h`
+
+- [ ] **Step 1: Add `#include "config.h"` to `Weather_Station_2.cpp`**
+
+Add as the first local include, before `#include "src/security/CACerts.h"` (line 24):
+
+```cpp
+#include "config.h"
+```
+
+- [ ] **Step 2: Replace hardcoded WiFi credentials**
+
+At line 44, replace:
+```cpp
+auto network = std::make_shared<Network>("NorwegianFish", "rufalina");
+```
+With:
+```cpp
+auto network = std::make_shared<Network>(WIFI_SSID, WIFI_PASSWORD);
+```
+
+- [ ] **Step 3: Replace hardcoded `BatteryLogger` URL**
+
+At line 221, replace the string literal with `BATTERY_LOGGER_URL`:
+```cpp
+BatteryLogger batteryLogger(BATTERY_LOGGER_URL);
+```
+
+- [ ] **Step 4: Pass `WEATHER_STATION_ID` to `CurrentConditions`**
+
+At line 64, replace:
+```cpp
+CurrentConditions curr(network);
+```
+With:
+```cpp
+CurrentConditions curr(network, WEATHER_STATION_ID);
+```
+
+- [ ] **Step 5: Remove the `= "KBFI"` default from `CurrentConditions.h`**
+
+In `CurrentConditions.h` at line 24, replace:
+```cpp
+CurrentConditions(std::shared_ptr<Network> network, const String station = "KBFI");
+```
+With:
+```cpp
+CurrentConditions(std::shared_ptr<Network> network, const String station);
+```
+
+- [ ] **Step 6: Compile the firmware**
+
+```bash
+cmake --build build
+```
+
+Expected: Compiles cleanly with no errors or warnings about undefined macros.
+
+- [ ] **Step 7: Flash and verify on device**
+
+```bash
+SERIAL_PORT=/dev/ttyUSB0 cmake --build build --target upload-WeatherStation
+arduino-cli monitor --port /dev/ttyUSB0 --config baudrate=115200
+```
+
+Press the physical wakeup button if the device is in deep sleep. Expected serial output:
+```
+Waiting for WiFi to connect. connected
+Waiting for NTP time sync: I: Current time: ...
+I: [HTTPS] GET... code: 200
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Weather_Station_2.cpp src/network/CurrentConditions.h
+git commit -m "$(cat <<'EOF'
+feat: replace hardcoded config values with config.h macros
+
+Closes #10
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-15-config-extraction-design.md
+++ b/docs/superpowers/specs/2026-04-15-config-extraction-design.md
@@ -1,0 +1,115 @@
+# Config Extraction Design
+
+Move hardcoded WiFi credentials, weather station ID, and battery logger URL out of source files into a git-ignored `config.cmake`, generated into a `config.h` header via CMake's `configure_file`.
+
+Closes #10.
+
+---
+
+## Problem
+
+Four environment-specific values are hardcoded in source files and cannot be safely committed:
+
+| Value | Current location |
+|---|---|
+| `WIFI_SSID` | `Weather_Station_2.cpp:44` |
+| `WIFI_PASSWORD` | `Weather_Station_2.cpp:44` |
+| `WEATHER_STATION_ID` | `CurrentConditions.h:24` (constructor default) |
+| `BATTERY_LOGGER_URL` | `Weather_Station_2.cpp:221` |
+
+## Approach
+
+**CMake `configure_file` pattern** — `config.cmake` sets CMake variables; `CMakeLists.txt` passes them through `configure_file` into `${CMAKE_BINARY_DIR}/generated/config.h`; source files `#include "config.h"`.
+
+Rejected alternatives:
+- `-D` flags at configure time: inconvenient, user must re-supply every reconfigure
+- `target_compile_definitions`: string escaping is fragile in CMake
+
+## C++ Standard Note
+
+The Inkplate platform compiles with `-std=gnu++11`. `std::string_view` (C++17) is unavailable. Config values are plain `#define` macros.
+
+---
+
+## New Files
+
+### `config.cmake.example` (committed)
+
+```cmake
+# Copy this file to config.cmake and fill in real values.
+# config.cmake is git-ignored and must never be committed.
+set(WIFI_SSID "your-ssid-here")
+set(WIFI_PASSWORD "your-password-here")
+set(WEATHER_STATION_ID "XXXX")
+set(BATTERY_LOGGER_URL "http://your-server/path")
+```
+
+### `src/config.h.in` (committed)
+
+```c
+// ABOUTME: CMake-generated header providing compile-time configuration values.
+// ABOUTME: Values are substituted by CMake at configure time from config.cmake.
+#ifndef CONFIG_H
+#define CONFIG_H
+#define WIFI_SSID "@WIFI_SSID@"
+#define WIFI_PASSWORD "@WIFI_PASSWORD@"
+#define WEATHER_STATION_ID "@WEATHER_STATION_ID@"
+#define BATTERY_LOGGER_URL "@BATTERY_LOGGER_URL@"
+#endif  // CONFIG_H
+```
+
+### `config.cmake` (git-ignored)
+
+User's local copy of `config.cmake.example` with real values. Never committed.
+
+---
+
+## Changed Files
+
+### `CMakeLists.txt`
+
+1. Near the top (before `add_executable`), include `config.cmake` with a clear error if missing:
+   ```cmake
+   if(NOT EXISTS "${CMAKE_SOURCE_DIR}/config.cmake")
+       message(FATAL_ERROR "config.cmake not found. Copy config.cmake.example to config.cmake and fill in your values.")
+   endif()
+   include(${CMAKE_SOURCE_DIR}/config.cmake)
+   ```
+
+2. After `add_executable(WeatherStation ...)`, add `configure_file` and **replace** the existing `target_include_directories` line (currently `target_include_directories(WeatherStation PRIVATE src)`) with the expanded form:
+   ```cmake
+   configure_file(src/config.h.in ${CMAKE_BINARY_DIR}/generated/config.h)
+   target_include_directories(WeatherStation PRIVATE src ${CMAKE_BINARY_DIR}/generated)
+   ```
+   These two lines belong together: `configure_file` generates the header and `target_include_directories` makes it findable. The existing `target_include_directories` line is removed, not duplicated.
+
+### `.gitignore`
+
+Add `config.cmake`.
+
+### `Weather_Station_2.cpp`
+
+- Add `#include "config.h"`
+- Replace `"NorwegianFish"` / `"rufalina"` with `WIFI_SSID` / `WIFI_PASSWORD`
+- Replace the `BatteryLogger` URL literal with `BATTERY_LOGGER_URL`
+- Pass `WEATHER_STATION_ID` explicitly when constructing `CurrentConditions` (line 64)
+
+### `CurrentConditions.h`
+
+- Remove the `= "KBFI"` default from the constructor declaration (line 24)
+
+### `CurrentConditions.cpp`
+
+No changes required. The station value is used only via `m_station`, which is set by the constructor parameter.
+
+---
+
+## Testing
+
+No automated test framework exists for this target. Verification:
+
+1. CMake configure fails with a clear message if `config.cmake` is absent
+2. CMake configure succeeds with `config.cmake` present
+3. `build/generated/config.h` contains the correct substituted values
+4. Firmware compiles without errors
+5. Device boots, connects to WiFi, and fetches weather (serial monitor confirms)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,0 +1,9 @@
+// ABOUTME: CMake-generated header providing compile-time configuration values.
+// ABOUTME: Values are substituted by CMake at configure time from config.cmake.
+#ifndef CONFIG_H
+#define CONFIG_H
+#define WIFI_SSID "@WIFI_SSID@"
+#define WIFI_PASSWORD "@WIFI_PASSWORD@"
+#define WEATHER_STATION_ID "@WEATHER_STATION_ID@"
+#define BATTERY_LOGGER_URL "@BATTERY_LOGGER_URL@"
+#endif  // CONFIG_H

--- a/src/network/CurrentConditions.h
+++ b/src/network/CurrentConditions.h
@@ -21,7 +21,7 @@ const int CURRENT_CONDITIONS_CERT_ERROR = -6;
 
 class CurrentConditions {
    public:
-    CurrentConditions(std::shared_ptr<Network> network, const String station = "KBFI");
+    CurrentConditions(std::shared_ptr<Network> network, const String station);
 
     // Returns error code, now with options for retries
     int update(int retries = 2);

--- a/src/user_settings.h.in
+++ b/src/user_settings.h.in
@@ -1,9 +1,9 @@
 // ABOUTME: CMake-generated header providing compile-time configuration values.
 // ABOUTME: Values are substituted by CMake at configure time from config.cmake.
-#ifndef CONFIG_H
-#define CONFIG_H
+#ifndef WEATHER_STATION_2_USER_SETTINGS_H
+#define WEATHER_STATION_2_USER_SETTINGS_H
 #define WIFI_SSID "@WIFI_SSID@"
 #define WIFI_PASSWORD "@WIFI_PASSWORD@"
 #define WEATHER_STATION_ID "@WEATHER_STATION_ID@"
 #define BATTERY_LOGGER_URL "@BATTERY_LOGGER_URL@"
-#endif  // CONFIG_H
+#endif  // WEATHER_STATION_2_USER_SETTINGS_H


### PR DESCRIPTION
## Summary

- Adds `config.cmake.example` (committed template) and git-ignores `config.cmake` (local credentials file)
- Wires `CMakeLists.txt` to generate `build/generated/weather_station_2/user_settings.h` via `configure_file`, with a `FATAL_ERROR` guard if `config.cmake` is missing
- Replaces four hardcoded literals (WiFi SSID/password, weather station ID, battery logger URL) in `Weather_Station_2.cpp` and removes the `= "KBFI"` default from `CurrentConditions.h`

The generated header is namespaced as `weather_station_2/user_settings.h` to avoid a collision with newlib's own `config.h` in the ESP32 SDK.

Closes #10.

## Test Plan

- [x] Copy `config.cmake.example` to `config.cmake` and fill in real values
- [x] `cmake -B build ...` — configure succeeds; `build/generated/weather_station_2/user_settings.h` contains substituted values
- [x] Remove `config.cmake` and re-configure — CMake exits with clear `FATAL_ERROR` message
- [x] `cmake --build build` — compiles cleanly
- [x] Flash device and confirm WiFi connects and weather data loads on serial monitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)