### PR TITLE
feat: containerized build environment with pinned toolchain (#15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Inkplate-Arduino-library/
 .private-journal/
 .worktrees/
 config.cmake
+venv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ Weather Station 2 is an Arduino/ESP32 project for the Inkplate 10 E-paper displa
 
 The device appears on `/dev/ttyUSB0`. The user must be in the `dialout` group (already configured). `arduino-cli board list` will show the port as "Unknown" — that's normal, the Inkplate FQBN can't be auto-detected.
 
+A `Containerfile` at the repo root provides a fully pinned build environment (see `docs/README.md`).
+
 ```bash
 # Configure (run from repo root, once or when CMakeLists.txt changes)
 cmake \
@@ -57,7 +59,7 @@ All application logic lives in `setup()` in `Weather_Station_2.cpp`. `loop()` is
 - `Weather_Station_2.cpp` includes a `std::make_unique` polyfill (lines 12–18) because the ESP32 Arduino core doesn't provide it.
 - `Kitties` uses `RTC_DATA_ATTR` to persist the image rotation counter across deep sleep cycles without hitting flash.
 - `CACerts` is a static `std::map<String, const char*>` mapping hostnames to PEM certs embedded as PROGMEM strings. Used by `Network` to configure `WiFiClientSecure` before each HTTPS request.
-- WiFi credentials are hardcoded in `Weather_Station_2.cpp` — there is no config file.
+- WiFi credentials and station ID are in `config.cmake` (gitignored; copy from `config.cmake.example`).
 - Weather station is hardcoded as `KBFI` (Seattle/Boeing Field) in `CurrentConditions.cpp`.
 
 ## Certificate Updates

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,11 @@ The device appears on `/dev/ttyUSB0`. The user must be in the `dialout` group (a
 
 A `Containerfile` at the repo root provides a fully pinned build environment (see `docs/README.md`).
 
+`config.cmake` is gitignored (it holds WiFi credentials). When setting up a new git worktree, copy it manually:
+```bash
+cp config.cmake .worktrees/<branch-name>/config.cmake
+```
+
 ```bash
 # Configure (run from repo root, once or when CMakeLists.txt changes)
 cmake \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,3 +55,6 @@ file(RENAME
     "${CMAKE_BINARY_DIR}/huge_app.csv"
     "${CMAKE_BINARY_DIR}/partitions.csv"
 )
+
+# ── Test sketches ─────────────────────────────────────────────────────────────
+add_subdirectory(tests)

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,55 @@
+# ABOUTME: Container build environment for Weather Station firmware.
+# ABOUTME: Pins arduino-cli, board support, and all library versions for reproducible builds.
+FROM ubuntu:24.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    python3 \
+    python3-pip \
+    python-is-python3 \
+    cmake \
+    ninja-build \
+    git \
+    clang-format \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pin arduino-cli version by downloading the release binary directly
+RUN curl -fsSL \
+    "https://github.com/arduino/arduino-cli/releases/download/v1.3.1/arduino-cli_1.3.1_Linux_64bit.tar.gz" \
+    | tar -xz -C /usr/local/bin arduino-cli
+
+# Stub Arduino IDE installation required by Arduino-CMake-Toolchain to locate packages.
+# The toolchain only checks for lib/version.txt; all actual tooling comes from ~/.arduino15.
+RUN mkdir -p /opt/arduino/lib && echo "1.8.16" > /opt/arduino/lib/version.txt
+
+# Stub preferences.txt so Arduino-CMake-Toolchain discovers the sketchbook path
+# (and thus ~/Arduino/libraries where arduino-cli installs user libraries).
+RUN mkdir -p /root/.arduino15 \
+    && echo "sketchbook.path=/root/Arduino" > /root/.arduino15/preferences.txt
+
+# Pin board support package
+RUN arduino-cli config add board_manager.additional_urls \
+        https://github.com/SolderedElectronics/Croduino-Board-Definitions-for-Arduino-IDE/raw/master/package_Croduino_Boards_index.json \
+    && arduino-cli core update-index \
+    && arduino-cli core install Croduino_Boards:Inkplate@1.0.1
+
+# Pin libraries
+RUN arduino-cli lib install \
+    "ArduinoJson@6.18.5" \
+    "ArduinoLog@1.1.1" \
+    "InkplateLibrary@10.2.2" \
+    "LCBUrl@1.1.4"
+
+# InkplateLibrary 10.2.2 calls WiFiClientSecure::setInsecure(), which does not exist in
+# the ESP32 Arduino 1.0.5-rc2 core bundled with Croduino_Boards:Inkplate@1.0.1.
+# setInsecure() was added in ESP32 Arduino 1.0.6; this patch keeps compilation working
+# against the pinned board core.
+RUN sed -i 's/^\( *\)client->setInsecure(); \/\/ Use HTTPS/\1\/\/ client->setInsecure(); \/\/ Use HTTPS/' \
+    /root/Arduino/libraries/InkplateLibrary/src/include/NetworkClient.cpp
+
+# Python tooling: image codegen (tools/image_converter.py) and esptool (board package).
+# --break-system-packages is required on Ubuntu 24.04, which ships with PEP 668
+# EXTERNALLY-MANAGED protection even inside a container.
+# pyserial is required by esptool.py (bundled in Croduino_Boards:Inkplate@1.0.1) to
+# generate the .bin from the compiled .elf.
+RUN pip3 install --no-cache-dir --break-system-packages Pillow numpy pyserial

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -70,6 +70,8 @@ Weather_Station_2/
 
 ## Development Commands
 
+A `Containerfile` at the repo root provides a fully pinned build environment (see `docs/README.md`).
+
 - **Configure**: `cmake -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake -B build -G Ninja`
 - **Compile**: `cmake --build build`
 - **Flash**: `SERIAL_PORT=/dev/ttyUSB0 cmake --build build --target upload-WeatherStation`
@@ -82,10 +84,7 @@ Weather_Station_2/
 
 ## Network Configuration
 
-WiFi credentials are hardcoded in Weather_Station_2.cpp setup() function:
-```cpp
-auto network = std::make_shared<Network>("SSID", "PASSWORD");
-```
+WiFi credentials and station ID are in `config.cmake` (gitignored; copy from `config.cmake.example`).
 
 ## Error Handling Strategy
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,55 @@ This project turns your Inkplate 10 into a weather station that displays:
 4. Open the project in Arduino IDE
 5. Upload the code to your Inkplate 10 device
 
+## Container build
+
+A `Containerfile` at the repo root pins all toolchain dependencies for a reproducible build without requiring a local Arduino IDE installation.
+
+### Build the image
+
+```bash
+podman build -t weather-station-builder .
+# or: docker build -t weather-station-builder .
+```
+
+### Compile firmware
+
+Copy `config.cmake.example` to `config.cmake` and fill in your WiFi credentials and station ID first.
+
+```bash
+# Podman (Linux with SELinux — the :Z flag relabels the volume for container access)
+podman run --rm -v $(pwd):/project:Z -w /project weather-station-builder \
+    bash -c "cmake \
+        -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake \
+        -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake \
+        -B build -G Ninja \
+    && cmake --build build"
+
+# Docker (or Podman without SELinux)
+docker run --rm -v $(pwd):/project -w /project weather-station-builder \
+    bash -c "cmake \
+        -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake \
+        -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake \
+        -B build -G Ninja \
+    && cmake --build build"
+```
+
+### Flash firmware
+
+The device appears on `/dev/ttyUSB0`. Your account must be in the `dialout` group on the host.
+
+```bash
+# Podman
+podman run --rm -v $(pwd):/project:Z --device /dev/ttyUSB0 -w /project \
+    weather-station-builder \
+    bash -c "SERIAL_PORT=/dev/ttyUSB0 cmake --build build --target upload-WeatherStation"
+
+# Docker
+docker run --rm -v $(pwd):/project --device /dev/ttyUSB0 -w /project \
+    weather-station-builder \
+    bash -c "SERIAL_PORT=/dev/ttyUSB0 cmake --build build --target upload-WeatherStation"
+```
+
 ## Features
 
 - Real-time weather data from weather.gov

--- a/docs/README.md
+++ b/docs/README.md
@@ -67,9 +67,10 @@ docker run --rm -v $(pwd):/project -w /project weather-station-builder \
 The device appears on `/dev/ttyUSB0`. Your account must be in the `dialout` group on the host.
 
 ```bash
-# Podman
-podman run --rm -v $(pwd):/project:Z --device /dev/ttyUSB0 -w /project \
-    weather-station-builder \
+# Podman — --group-add keep-groups passes your host supplementary groups (including
+# dialout) into the container, required for rootless Podman to access the serial port.
+podman run --rm -v $(pwd):/project:Z --device /dev/ttyUSB0 --group-add keep-groups \
+    -w /project weather-station-builder \
     bash -c "SERIAL_PORT=/dev/ttyUSB0 cmake --build build --target upload-WeatherStation"
 
 # Docker

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,5 @@
+# CMakeLists.txt
+# ABOUTME: Top-level CMake entry point for device test sketches.
+# ABOUTME: Each subdirectory defines an independent, flashable test target.
+
+add_subdirectory(calibration)

--- a/tests/calibration/CMakeLists.txt
+++ b/tests/calibration/CMakeLists.txt
@@ -1,0 +1,12 @@
+# CMakeLists.txt
+# ABOUTME: Build target for the grayscale calibration test sketch.
+# ABOUTME: Standalone Inkplate target with no network or sensor dependencies.
+
+add_executable(GrayscaleCalibration
+    GrayscaleCalibration.cpp
+)
+target_link_arduino_libraries(GrayscaleCalibration PRIVATE
+    core
+    Inkplate
+)
+target_enable_arduino_upload(GrayscaleCalibration)

--- a/tests/calibration/CMakeLists.txt
+++ b/tests/calibration/CMakeLists.txt
@@ -2,6 +2,17 @@
 # ABOUTME: Build target for the grayscale calibration test sketch.
 # ABOUTME: Standalone Inkplate target with no network or sensor dependencies.
 
+# Partition table — toolchain expects partitions.csv in the target's binary dir.
+# The calibration sketch is small; the default partition scheme is sufficient.
+file(COPY
+    "${ARDUINO_BOARD_RUNTIME_PLATFORM_PATH}/tools/partitions/default.csv"
+    DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
+)
+file(RENAME
+    "${CMAKE_CURRENT_BINARY_DIR}/default.csv"
+    "${CMAKE_CURRENT_BINARY_DIR}/partitions.csv"
+)
+
 add_executable(GrayscaleCalibration
     GrayscaleCalibration.cpp
 )

--- a/tests/calibration/GrayscaleCalibration.cpp
+++ b/tests/calibration/GrayscaleCalibration.cpp
@@ -1,0 +1,43 @@
+// ABOUTME: Calibration sketch for Inkplate 10 grayscale levels.
+// ABOUTME: Cycles through all 8 shades on button press for luminance measurement.
+
+#include <Arduino.h>
+#include <Inkplate.h>
+
+#define WAKEUP_BUTTON_PIN 36
+
+Inkplate display(INKPLATE_3BIT);
+
+static int shade = 0;
+
+void setup() {
+    display.begin();
+    pinMode(WAKEUP_BUTTON_PIN, INPUT);
+}
+
+void loop() {
+    display.clearDisplay();
+    display.fillScreen(shade);
+
+    // Contrasting text so the label is always legible against any shade
+    display.setTextColor(7 - shade);
+    display.setTextSize(5);
+    display.setCursor(50, 50);
+    display.print("Shade: ");
+    display.print(shade);
+    display.print(" / 7");
+
+    display.setTextSize(2);
+    display.setCursor(50, 180);
+    display.print("Press button to advance");
+
+    display.display();
+
+    // Wait for wakeup button (GPIO 36 goes LOW on press)
+    while (digitalRead(WAKEUP_BUTTON_PIN) == HIGH) {
+        delay(50);
+    }
+    delay(200);  // debounce
+
+    shade = (shade + 1) % 8;
+}

--- a/tests/calibration/GrayscaleCalibration.cpp
+++ b/tests/calibration/GrayscaleCalibration.cpp
@@ -19,8 +19,10 @@ void loop() {
     display.clearDisplay();
     display.fillScreen(shade);
 
-    // Contrasting text so the label is always legible against any shade
-    display.setTextColor(7 - shade);
+    // Contrasting text so the label is always legible against any shade.
+    // Two-arg form required: setTextColor(fg, bg) — one-arg sets fg==bg, making
+    // text invisible.
+    display.setTextColor(7 - shade, shade);
     display.setTextSize(5);
     display.setCursor(50, 50);
     display.print("Shade: ");
@@ -28,6 +30,7 @@ void loop() {
     display.print(" / 7");
 
     display.setTextSize(2);
+    display.setTextColor(7 - shade, shade);
     display.setCursor(50, 180);
     display.print("Press button to advance");
 

--- a/tools/extract_shade_luminance.py
+++ b/tools/extract_shade_luminance.py
@@ -1,0 +1,86 @@
+# ABOUTME: Extracts per-shade luminance from calibration photos of the Inkplate display.
+# ABOUTME: Reads JPEG files, inverts sRGB gamma to linear light, outputs INKPLATE_SHADE_LUMINANCE.
+
+"""
+Usage:
+    python3 tools/extract_shade_luminance.py ~/Pictures/"Inkplate Calibration"
+
+Expects exactly 8 JPEG files in the directory, sorted by filename, corresponding
+to Inkplate shades 0-7 photographed in ascending order.
+
+Output is the INKPLATE_SHADE_LUMINANCE table for use in the image conversion
+pipeline (tools/image_converter.py).
+"""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+
+# Sample the centre N% of the image to avoid edges and vignetting
+SAMPLE_FRACTION = 0.15
+
+
+def srgb_to_linear(values: np.ndarray) -> np.ndarray:
+    """Invert sRGB gamma encoding to get linear light values (0.0-1.0)."""
+    v = values / 255.0
+    return np.where(v <= 0.04045, v / 12.92, ((v + 0.055) / 1.055) ** 2.4)
+
+
+def extract_linear_luminance(jpeg_path: Path) -> float:
+    """Return mean linear luminance (0.0-1.0) from the centre of a JPEG."""
+    img = Image.open(jpeg_path).convert("RGB")
+    arr = np.asarray(img, dtype=np.float32)
+
+    h, w = arr.shape[:2]
+    dy = int(h * SAMPLE_FRACTION)
+    dx = int(w * SAMPLE_FRACTION)
+    cy, cx = h // 2, w // 2
+    centre = arr[cy - dy : cy + dy, cx - dx : cx + dx]
+
+    linear = srgb_to_linear(centre)
+
+    # Rec. 709 luminance weights
+    luma = 0.2126 * linear[:, :, 0] + 0.7152 * linear[:, :, 1] + 0.0722 * linear[:, :, 2]
+    return float(luma.mean())
+
+
+def main(calibration_dir: Path) -> None:
+    jpeg_files = sorted(calibration_dir.glob("*.JPG"))
+    if not jpeg_files:
+        jpeg_files = sorted(calibration_dir.glob("*.jpg"))
+
+    if len(jpeg_files) != 8:
+        print(f"Error: expected 8 JPEG files, found {len(jpeg_files)}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Reading {len(jpeg_files)} JPEG files from {calibration_dir}\n")
+
+    raw_luminances = []
+    for shade, path in enumerate(jpeg_files):
+        luma = extract_linear_luminance(path)
+        raw_luminances.append(luma)
+        print(f"  shade {shade}: {path.name}  ->  linear luma = {luma:.5f}")
+
+    max_luma = raw_luminances[-1]
+    if max_luma == 0:
+        print("Error: shade 7 has zero luminance — check the photo", file=sys.stderr)
+        sys.exit(1)
+
+    normalised = [v / max_luma for v in raw_luminances]
+
+    print("\n# Paste this into tools/image_converter.py:")
+    print("INKPLATE_SHADE_LUMINANCE = [")
+    for shade, v in enumerate(normalised):
+        print(f"    {v:.4f},  # shade {shade}")
+    print("]")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <calibration_dir>", file=sys.stderr)
+        sys.exit(1)
+
+    main(Path(sys.argv[1]).expanduser())


### PR DESCRIPTION
## Summary

- Adds `Containerfile` pinning the full build toolchain: arduino-cli 1.3.1, `Croduino_Boards:Inkplate@1.0.1`, and all four Arduino libraries at their current working versions
- Patches `InkplateLibrary@10.2.2` via `sed` to comment out `WiFiClientSecure::setInsecure()`, which doesn't exist in the ESP32 Arduino 1.0.5-rc2 core bundled in the board package (added in 1.0.6); tracked in #27 and #28
- Updates `CLAUDE.md` (root and `docs/`) to reference the Containerfile and correct the WiFi credentials note to reflect `config.cmake`
- Updates `docs/README.md` with compile and flash instructions for both Podman and Docker

## Test plan

- [x] `podman build -t weather-station-builder .` completes cleanly
- [x] `cmake` configure + `cmake --build` inside container compiles all 148 units and produces `WeatherStation.bin`
- [x] Flash via `podman run --device /dev/ttyUSB0 --group-add keep-groups` successfully flashed hardware and device booted

## Notes

- `--group-add keep-groups` is required for rootless Podman to forward the host `dialout` group into the container for serial port access
- Two follow-on issues filed: #27 (upgrade board core from ESP32 Arduino 1.0.5-rc2) and #28 (replace InkplateLibrary install + sed patch with fork + submodule)

Closes #15