### PR TITLE
feat: add TDD infrastructure (GoogleTest host + AUnit device)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,8 @@
       "Bash(rm -rf /home/jesse/Arduino/Weather_Station_2/build)",
       "Bash(mkdir -p /home/jesse/Arduino/Weather_Station_2/build)",
       "Bash(git:*)",
-      "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); print\\(d['title']\\); print\\(\\); print\\(d['body']\\)\")"
+      "Bash(python3 -c \"import json,sys; d=json.load\\(sys.stdin\\); print\\(d['title']\\); print\\(\\); print\\(d['body']\\)\")",
+      "mcp__private-journal__process_thoughts"
     ],
     "deny": [],
     "ask": []

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Inkplate-Arduino-library/
 .worktrees/
 config.cmake
 venv
+build-host/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,9 @@
 [submodule "cmake/Arduino-CMake-Toolchain"]
 	path = cmake/Arduino-CMake-Toolchain
 	url = https://github.com/a9183756-gh/Arduino-CMake-Toolchain.git
+[submodule "libs/googletest"]
+	path = libs/googletest
+	url = https://github.com/google/googletest
+[submodule "libs/AUnit"]
+	path = libs/AUnit
+	url = https://github.com/bxparks/AUnit

--- a/Weather_Station_2.cpp
+++ b/Weather_Station_2.cpp
@@ -22,7 +22,9 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 #endif
 
 #include "weather_station_2/user_settings.h"
-#include "src/security/CACerts.h"
+#include "src/network/IClock.h"
+#include "src/network/IHttpClient.h"
+#include "src/network/SystemClock.h"
 #include "src/network/CurrentConditions.h"
 #include "src/display/DisplayLocations.h"
 #include "assets/fonts/Roboto_Light.h"
@@ -62,7 +64,8 @@ void setup() {
 
     network->begin();
 
-    CurrentConditions curr(network, WEATHER_STATION_ID);
+    SystemClock clock;
+    CurrentConditions curr(*network, clock, WEATHER_STATION_ID);
 
     const uint8_t* nextKitty = Kitties::getNextKitty();
 

--- a/docs/superpowers/plans/2026-04-16-containerized-build.md
+++ b/docs/superpowers/plans/2026-04-16-containerized-build.md
@@ -1,0 +1,277 @@
+# Containerized Build Environment Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Commit a `Containerfile` that fully pins the Weather Station build toolchain (arduino-cli, board support package, all libraries) so any developer can reproduce the exact build environment without fighting Arduino IDE setup.
+
+**Architecture:** A single Ubuntu 24.04 container installs arduino-cli 1.3.1, the Inkplate board support package, all required Arduino libraries, and Python tools. Users mount their project directory (which includes their personal `config.cmake`) and run cmake configure + build inside the container. Flash is done by passing `/dev/ttyUSB0` through to the container.
+
+**Tech Stack:** Ubuntu 24.04, arduino-cli 1.3.1, CMake + Ninja, Podman/Docker
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `Containerfile` | Create | Pinned build environment definition |
+| `docs/README.md` | Modify | Add "Building with the container" section documenting image build, compile, and flash |
+
+---
+
+## Chunk 1: Containerfile + README
+
+### Task 1: Create feature branch
+
+- [ ] **Step 1: Create and check out the feature branch**
+
+  ```bash
+  git checkout -b feat/containerized-build
+  ```
+
+---
+
+### Task 2: Write the Containerfile
+
+**Files:**
+- Create: `Containerfile`
+
+Before writing, verify the board index URL works. The local `~/.arduino15/package_Croduino_Boards_index.json` was placed there manually. Check the Dasduino/Soldered URL from the issue sketch is reachable:
+
+```bash
+curl -fsSL --head \
+  "https://github.com/SolderedElectronics/Dasduino-Board-Support-Package-Installer/raw/master/package_Dasduino_Boards_index.json" \
+  | head -5
+```
+
+Expected: HTTP 200 (or 302 redirect). If this URL is dead, fall back to:
+`https://github.com/SolderedElectronics/Croduino-Board-Definitions-for-Arduino-IDE/raw/master/package_Croduino_Boards_index.json`
+(the board package itself downloads from `github.com/SolderedElectronics/Croduino-Board-Definitions-for-Arduino-IDE`).
+
+- [ ] **Step 2: Create `Containerfile`**
+
+  Pinned versions (from `arduino-cli core list` and `arduino-cli lib list` on the reference machine):
+  - arduino-cli: `1.3.1`
+  - Board: `Croduino_Boards:Inkplate@1.0.1`
+  - ArduinoJson: `6.18.5`
+  - ArduinoLog: `1.1.1`
+  - InkplateLibrary: `10.2.2`
+  - LCBUrl: `1.1.4`
+
+  ```dockerfile
+  # ABOUTME: Container build environment for Weather Station firmware.
+  # ABOUTME: Pins arduino-cli, board support, and all library versions for reproducible builds.
+  FROM ubuntu:24.04
+
+  RUN apt-get update && apt-get install -y --no-install-recommends \
+      curl \
+      python3 \
+      python3-pip \
+      cmake \
+      ninja-build \
+      git \
+      clang-format \
+      && rm -rf /var/lib/apt/lists/*
+
+  # Pin arduino-cli version
+  RUN curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh \
+      | BINDIR=/usr/local/bin sh -s 1.3.1
+
+  # Pin board support package
+  RUN arduino-cli config add board_manager.additional_urls \
+          https://github.com/SolderedElectronics/Dasduino-Board-Support-Package-Installer/raw/master/package_Dasduino_Boards_index.json \
+      && arduino-cli core update-index \
+      && arduino-cli core install Croduino_Boards:Inkplate@1.0.1
+
+  # Pin libraries
+  RUN arduino-cli lib install \
+      "ArduinoJson@6.18.5" \
+      "ArduinoLog@1.1.1" \
+      "InkplateLibrary@10.2.2" \
+      "LCBUrl@1.1.4"
+
+  # Python tooling for image codegen (tools/image_converter.py)
+  RUN pip3 install --no-cache-dir --break-system-packages Pillow numpy
+  ```
+
+---
+
+### Task 3: Verify container builds
+
+- [ ] **Step 3: Build the container image**
+
+  ```bash
+  podman build -t weather-station-builder .
+  ```
+
+  Expected: build completes without error. Each `RUN` layer should succeed.
+
+  **If `arduino-cli lib install "InkplateLibrary@10.2.2"` fails:** The library may have a different name in the Arduino Library Manager. Try `arduino-cli lib search inkplate` inside a running container to find the correct name. If it's only available via git (not the library registry), replace the lib install line with:
+  ```dockerfile
+  RUN git clone --depth 1 --branch 10.2.2 \
+      https://github.com/SolderedElectronics/Inkplate-Arduino-library.git \
+      /root/Arduino/libraries/Inkplate
+  ```
+
+  **If the board URL returns 404:** Try the fallback URL mentioned in Task 2.
+
+- [ ] **Step 4: Verify Arduino libraries are discoverable**
+
+  The CMakeLists.txt references libraries as `Inkplate`, `ArduinoJson`, `ArduinoLog`, `LCBUrl`. Arduino-CMake-Toolchain finds them via `library.properties` in `$HOME/Arduino/libraries/`. Verify the installed library names match:
+
+  ```bash
+  podman run --rm weather-station-builder \
+      bash -c "ls ~/Arduino/libraries/"
+  ```
+
+  Expected output lists directories including: `ArduinoJson`, `ArduinoLog`, `LCBUrl`, and one containing `InkplateLibrary` or `Inkplate`.
+
+  The `library.properties` `name=` field must match what CMakeLists.txt requests. Check:
+  ```bash
+  podman run --rm weather-station-builder \
+      bash -c "grep '^name=' ~/Arduino/libraries/InkplateLibrary/library.properties"
+  ```
+  Expected: `name=Inkplate` (or similar). If the name is `InkplateLibrary`, the CMakeLists.txt will also need updating — but don't change CMakeLists.txt unless the build fails with a "library not found" error; try the build first (Step 5).
+
+---
+
+### Task 4: Verify firmware compiles inside the container
+
+The project requires `config.cmake` at the repo root (it holds WiFi credentials and is gitignored). A minimal stub is enough to test the build:
+
+- [ ] **Step 5: Create a test config stub and run cmake configure**
+
+  ```bash
+  # Create a minimal config for build testing (credentials don't matter for compilation)
+  cat > /tmp/test-config.cmake <<'EOF'
+  set(WIFI_SSID "test")
+  set(WIFI_PASSWORD "test")
+  set(WEATHER_STATION_ID "KBFI")
+  set(BATTERY_LOGGER_URL "http://localhost/path")
+  EOF
+
+  podman run --rm \
+      -v $(pwd):/project:Z \
+      -v /tmp/test-config.cmake:/project/config.cmake:Z \
+      -w /project \
+      weather-station-builder \
+      bash -c "rm -rf build && cmake \
+          -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake \
+          -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake \
+          -B build \
+          -G Ninja"
+  ```
+
+  Expected: cmake configure completes successfully and prints board/toolchain detection info.
+
+- [ ] **Step 6: Run the firmware compile**
+
+  ```bash
+  podman run --rm \
+      -v $(pwd):/project:Z \
+      -v /tmp/test-config.cmake:/project/config.cmake:Z \
+      -w /project \
+      weather-station-builder \
+      cmake --build build
+  ```
+
+  Expected: compiles without errors, produces `build/WeatherStation.bin`.
+
+  **If build fails with "Inkplate not found":** The library name mismatch described in Step 4 is the likely cause. Either the `InkplateLibrary` directory needs to be symlinked/renamed in the container, or the git-based install from Step 3's fallback installs to a path CMake can find. Debug by inspecting which path Arduino-CMake-Toolchain is searching:
+  ```bash
+  podman run --rm -v $(pwd):/project:Z -w /project weather-station-builder \
+      cmake -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake \
+            -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake \
+            -B build -G Ninja 2>&1 | grep -i inkplate
+  ```
+
+---
+
+### Task 5: Update docs/README.md
+
+**Files:**
+- Modify: `docs/README.md`
+
+Add a "Building with the container" section. Place it after the existing "Installation" section (which currently describes the Arduino IDE path — leave that section intact).
+
+- [ ] **Step 7: Add container build section to docs/README.md**
+
+  ```markdown
+  ## Container build (recommended)
+
+  A `Containerfile` at the repo root pins all toolchain dependencies for reproducible builds.
+
+  ### Build the image
+
+  ```bash
+  # Podman
+  podman build -t weather-station-builder .
+
+  # Docker
+  docker build -t weather-station-builder .
+  ```
+
+  ### Compile firmware
+
+  ```bash
+  # Copy config.cmake.example → config.cmake and fill in your credentials first.
+  cp config.cmake.example config.cmake
+  # edit config.cmake
+
+  # Podman (Linux with SELinux)
+  podman run --rm -v $(pwd):/project:Z -w /project weather-station-builder \
+      bash -c "cmake \
+          -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake \
+          -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake \
+          -B build -G Ninja \
+      && cmake --build build"
+
+  # Docker / Podman without SELinux (drop the :Z)
+  docker run --rm -v $(pwd):/project -w /project weather-station-builder \
+      bash -c "cmake \
+          -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake \
+          -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake \
+          -B build -G Ninja \
+      && cmake --build build"
+  ```
+
+  ### Flash firmware
+
+  The device appears on `/dev/ttyUSB0`. Your host account needs to be in the `dialout` group.
+
+  ```bash
+  # Podman
+  podman run --rm \
+      -v $(pwd):/project:Z \
+      --device /dev/ttyUSB0 \
+      -w /project \
+      weather-station-builder \
+      bash -c "SERIAL_PORT=/dev/ttyUSB0 cmake --build build --target upload-WeatherStation"
+
+  # Docker
+  docker run --rm \
+      -v $(pwd):/project \
+      --device /dev/ttyUSB0 \
+      -w /project \
+      weather-station-builder \
+      bash -c "SERIAL_PORT=/dev/ttyUSB0 cmake --build build --target upload-WeatherStation"
+  ```
+  ```
+
+---
+
+### Task 6: Commit
+
+- [ ] **Step 8: Stage and commit**
+
+  ```bash
+  git add Containerfile docs/README.md
+  git status  # verify only these two files are staged
+  git commit -m "feat: add Containerfile with pinned build toolchain
+
+  Pins arduino-cli 1.3.1, Croduino_Boards:Inkplate 1.0.1, and all
+  Arduino library versions so the build environment is fully reproducible
+  without requiring a local Arduino IDE installation.
+
+  Closes #15"
+  ```

--- a/docs/superpowers/specs/2026-04-17-tdd-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-04-17-tdd-infrastructure-design.md
@@ -1,0 +1,167 @@
+# TDD Infrastructure Design
+
+## Context
+
+The Weather Station 2 codebase grew from a hobbyist example sketch and lacks test coverage.
+Adding features (e.g. a 24-hour rainfall graph) is risky without tests, and the code is
+tightly coupled to hardware, making logic bugs hard to catch before flashing. This design
+introduces a hybrid testing approach: GoogleTest for pure C++ logic on the host, AUnit for
+hardware integration on the Inkplate device. A minimal interface refactor unlocks testing
+of the most complex logic (`CurrentConditions::update()`) without over-engineering.
+
+---
+
+## Phase 0: Dependency Setup
+
+**Goal:** Wire in test libraries as git submodules before writing any tests.
+
+### Submodules
+
+| Library | URL | Path |
+|---------|-----|------|
+| GoogleTest | https://github.com/google/googletest | `libs/googletest` |
+| AUnit | https://github.com/bxparks/AUnit | `libs/AUnit` |
+
+### CMake Integration
+
+- **Host tests:** A separate CMake configuration (`build-host/`) is used — no Arduino
+  toolchain. The `if(NOT CMAKE_CROSSCOMPILING)` guard that pulls in GoogleTest and
+  `tests/unit/` lives in `tests/CMakeLists.txt` (not the root), so the root file is
+  unchanged and the device build is unaffected.
+- **Device tests:** AUnit is declared as a dependency via `target_link_arduino_libraries`
+  in each device test sketch's `CMakeLists.txt`, pointing at `libs/AUnit`.
+
+### Deliverable
+
+`cmake -B build-host && cmake --build build-host --target tests` compiles and runs an
+empty GoogleTest suite. Existing `cmake -B build` firmware build is unaffected.
+
+---
+
+## Phase 1: Pure Logic Tests
+
+**Goal:** Test all logic that requires zero hardware, with minimal source changes.
+
+### Source Changes
+
+| Location | Change |
+|----------|--------|
+| `CACerts::getCert()` | Parameter changes from `const String&` to `const std::string&`; map key type changes from `std::map<String, …>` to `std::map<std::string, …>`. Return type is already `const char*` — no change. |
+| `CurrentConditions::validateData()` | Move from `private` to `public` to enable direct testing. No other changes — the method has no `String` usage (operates only on `int` members). |
+| `Kitties.h` | Add portability guard: `#ifndef RTC_DATA_ATTR` / `#define RTC_DATA_ATTR` / `#endif`. `RTC_DATA_ATTR` is an ESP32 macro absent on the host; the guard makes `Kitties` compile in both environments. Behavior on device is unchanged. |
+
+Call sites in `Weather_Station_2.cpp` get a thin `String(result.c_str())` conversion where
+`getCert()` is called. No other files change.
+
+### Host Tests (`tests/unit/`)
+
+| File | Tests |
+|------|-------|
+| `CACertsTest.cpp` | Known hostname returns the cert (`const char*`); unknown hostname returns `nullptr` |
+| `KittiesTest.cpp` | Index cycles through 0–4 via modulo after 5 calls; after 256 calls (uint8_t overflow) the cycle still works correctly |
+| `CurrentConditionsTest.cpp` | `validateData()` passes valid data; rejects out-of-range temperature; rejects out-of-range dew point; rejects dew point more than 5°C above temperature; rejects negative or excessive wind speed; `getErrorString()` maps all seven error code constants to non-empty strings |
+
+### Device Sketch (`tests/device/unit/`)
+
+Same assertions compiled with AUnit + `aunit/contrib/gtest.h` adapter.
+
+**Constraint:** The AUnit gtest adapter supports only `ASSERT_*` macros. `EXPECT_*` macros
+and `TEST_F()` are not available. All tests in both host and device suites must be written
+using `ASSERT_*` and plain `TEST()` blocks to ensure the same test code compiles on both
+platforms.
+
+Serial output monitored manually for PASS/FAIL.
+
+### Deliverable
+
+`cmake --build build-host --target tests` passes. Device sketch flashes and reports all
+green over serial.
+
+---
+
+## Phase 2: Minimal Interface Refactor
+
+**Goal:** Make `CurrentConditions::update()` fully testable on the host via two minimal
+interfaces. No other abstractions introduced (YAGNI).
+
+### Interfaces
+
+**`IClock`** — abstracts `millis()` for cache timeout logic:
+```cpp
+class IClock {
+public:
+    virtual ~IClock() = default;
+    virtual unsigned long millis() const = 0;
+};
+```
+
+**`IHttpClient`** — abstracts the HTTP GET operation:
+```cpp
+class IHttpClient {
+public:
+    virtual ~IHttpClient() = default;
+    virtual int get(const std::string& url, std::string& body) = 0;
+};
+```
+
+### Concrete Implementations
+
+| Interface | Production Implementation |
+|-----------|--------------------------|
+| `IClock` | `SystemClock` — calls `::millis()` |
+| `IHttpClient` | `Network` — adds a new `get(const std::string&, std::string&)` override implementing the interface. The existing `get(WiFiClientSecure&, …)` signature is unchanged and used internally. |
+
+**Cert lookup migration:** `CACerts::getCert()` is currently called in
+`CurrentConditions::update()`. When `Network` implements `IHttpClient`, the cert lookup
+moves inside `Network`'s `IHttpClient::get()` implementation, since `WiFiClientSecure` is
+only visible there. `CurrentConditions` no longer references `CACerts` directly.
+
+### Refactor
+
+- `CurrentConditions` constructor signature changes to take `IHttpClient&` and `IClock&`
+  instead of `shared_ptr<Network>`
+- `m_network` member type changes from `std::shared_ptr<Network>` to `IHttpClient&`
+  (non-owning reference). This makes `CurrentConditions` non-copyable and
+  non-move-assignable — acceptable given the embedded lifecycle (all objects constructed
+  in `setup()`, nothing is copied)
+- All `millis()` call sites inside `CurrentConditions` (lines 67 and 103) replaced with
+  `m_clock.millis()`
+- `Weather_Station_2.cpp` constructs a `SystemClock` instance and passes it alongside
+  `Network` to `CurrentConditions`
+
+### New Tests Unlocked (`CurrentConditionsTest.cpp`)
+
+Note: the cache timeout is 1,800,000 ms (30 minutes). Clock mocks must advance by more
+than this value to trigger a re-fetch.
+
+- Cache returns stale data when clock has not advanced past 1,800,000 ms
+- Cache expires and triggers re-fetch when clock advances past 1,800,000 ms
+- `update()` parses and validates a canned JSON response correctly
+- `update()` handles network errors and HTTP error codes
+- `update()` rejects malformed JSON
+
+### Deliverable
+
+`CurrentConditions` fully covered on host. `Network` hardware behavior remains
+device-only.
+
+---
+
+## Phase 3: Rainfall Graph (Placeholder)
+
+Out of scope for this spec. Gets its own brainstorm and design after Phases 0–2 are
+merged. The clean foundation (testable `CurrentConditions`, injectable interfaces) enables
+the graph feature to be built test-first from day one.
+
+Anticipated scope: fetch 24-hour precipitation forecast from `api.weather.gov`, render a
+graph on the Inkplate display.
+
+---
+
+## Verification
+
+| Phase | How to verify |
+|-------|---------------|
+| 0 | `cmake -B build-host && cmake --build build-host --target tests` runs empty suite; `cmake -B build` firmware build unchanged |
+| 1 | Host test suite passes; device unit sketch reports all PASS over serial |
+| 2 | Host test suite passes including `CurrentConditions::update()` tests; firmware boots and functions normally |

--- a/src/display/Kitties.h
+++ b/src/display/Kitties.h
@@ -3,6 +3,10 @@
 
 #include <stdint.h>
 
+#ifndef RTC_DATA_ATTR
+#define RTC_DATA_ATTR
+#endif
+
 #define NUM_OF_KITTIES 5
 
 class Kitties {

--- a/src/network/CurrentConditions.cpp
+++ b/src/network/CurrentConditions.cpp
@@ -38,7 +38,7 @@ int CurrentConditions::update(int retries) {
     // Reset last error
     lastError = CURRENT_CONDITIONS_OK;
 
-    client.setCACert(CACerts::getCert(m_url.getHost()));
+    client.setCACert(CACerts::getCert(m_url.getHost().c_str()));
 
     Log.notice(F("Getting Current Conditions" CR));
 

--- a/src/network/CurrentConditions.cpp
+++ b/src/network/CurrentConditions.cpp
@@ -2,24 +2,29 @@
 // ABOUTME: Parses observation JSON and exposes temperature, wind, dew point, and description.
 #include "CurrentConditions.h"
 
-#include <ArduinoLog.h>
-#include <WiFiClientSecure.h>
-
 #include <cstdio>
 
-#include "../security/CACerts.h"
+#ifdef ARDUINO
+#include <ArduinoLog.h>
+#define CC_LOG_ERROR(fmt, ...) Log.errorln(fmt, ##__VA_ARGS__)
+#define CC_LOG_WARNING(fmt, ...) Log.warningln(fmt, ##__VA_ARGS__)
+#define CC_LOG_NOTICE(fmt, ...) Log.noticeln(fmt, ##__VA_ARGS__)
+#define CC_LOG_INFO(fmt, ...) Log.infoln(fmt, ##__VA_ARGS__)
+#else
+#define CC_LOG_ERROR(fmt, ...)
+#define CC_LOG_WARNING(fmt, ...)
+#define CC_LOG_NOTICE(fmt, ...)
+#define CC_LOG_INFO(fmt, ...)
+#endif
 
 static const char* url_format = "https://api.weather.gov/stations/%s/observations/latest";
 static unsigned int json_size = 768;
 
-CurrentConditions::CurrentConditions(std::shared_ptr<Network> network, const String station)
-    : m_network(network), m_station(station), m_doc(json_size) {
+CurrentConditions::CurrentConditions(IHttpClient& http, IClock& clock, const std::string& station)
+    : m_http(http), m_clock(clock), m_doc(json_size) {
     char buffer[256];
-    sprintf(buffer, url_format, m_station.c_str());
-    if (!m_url.setUrl(buffer)) {
-        Log.error(F("Failure to set URL: %s" CR), buffer);
-        lastError = CURRENT_CONDITIONS_ERROR;
-    }
+    snprintf(buffer, sizeof(buffer), url_format, station.c_str());
+    m_url = buffer;
 
     JsonObject filter_properties = m_filter.createNestedObject("properties");
     filter_properties["textDescription"] = true;
@@ -28,71 +33,59 @@ CurrentConditions::CurrentConditions(std::shared_ptr<Network> network, const Str
     filter_properties["dewpoint"] = true;
     filter_properties["temperature"] = true;
 
-    Log.notice(F("Set Current Conditions URL to %s" CR), m_url.getUrl().c_str());
+    CC_LOG_NOTICE("Set Current Conditions URL to %s", m_url.c_str());
 }
 
 int CurrentConditions::update(int retries) {
-    WiFiClientSecure client;
-    StreamString stream;
-
-    // Reset last error
     lastError = CURRENT_CONDITIONS_OK;
+    std::string body;
 
-    client.setCACert(CACerts::getCert(m_url.getHost().c_str()));
+    CC_LOG_NOTICE("Getting Current Conditions");
 
-    Log.notice(F("Getting Current Conditions" CR));
+    int networkResult = m_http.get(m_url, body);
 
-    // Get data with retries
-    int networkResult = m_network->get(client, m_url.getUrl(), stream, retries);
+    if (networkResult != 0) {
+        CC_LOG_ERROR("Network error code: %d", networkResult);
 
-    if (networkResult != NETWORK_OK) {
-        Log.error(F("Network error: %s" CR), m_network->getErrorString(networkResult));
-
-        // Map network errors to our error codes
+        // Map NetworkError enum values (defined in Network.h) by their integer
+        // values. CurrentConditions no longer includes Network.h to keep host
+        // compilation clean. These values must stay in sync with NetworkError.
         switch (networkResult) {
-            case NETWORK_WIFI_ERROR:
-            case NETWORK_HTTP_ERROR:
-            case NETWORK_TIMEOUT_ERROR:
-            case NETWORK_NO_DATA:
+            case -1: case -2: case -3: case -4:
                 lastError = CURRENT_CONDITIONS_NETWORK_ERROR;
                 break;
-            case NETWORK_CERT_ERROR:
+            case -5:
                 lastError = CURRENT_CONDITIONS_CERT_ERROR;
                 break;
             default:
                 lastError = CURRENT_CONDITIONS_ERROR;
         }
 
-        // If we have previous valid data that's not too old (30 minutes), use it
-        if (m_last_valid.valid && (millis() - m_last_update_time < 1800000)) {
-            Log.warning(F("Using cached weather data from previous update" CR));
+        if (m_last_valid.valid && (m_clock.millis() - m_last_update_time < 1800000)) {
+            CC_LOG_WARNING("Using cached weather data from previous update");
             description = m_last_valid.description.c_str();
             raw_message = m_last_valid.raw_message.c_str();
             temperature = m_last_valid.temperature;
             dew_point = m_last_valid.dew_point;
             wind_speed = m_last_valid.wind_speed;
-            return lastError;  // Return error but we've set fallback data
+            return lastError;
         }
 
         return lastError;
     }
 
-    // Check if we got any data
-    if (stream.length() == 0) {
-        Log.error(F("Empty response from server" CR));
+    if (body.empty()) {
+        CC_LOG_ERROR("Empty response from server");
         lastError = CURRENT_CONDITIONS_NETWORK_ERROR;
         return lastError;
     }
 
-    // Parse the JSON data
-    int parseResult = this->parse(stream);
+    int parseResult = this->parse(body);
 
-    // Validate the data
     if (parseResult == CURRENT_CONDITIONS_OK && !validateData()) {
         parseResult = CURRENT_CONDITIONS_INVALID_DATA;
     }
 
-    // If parsing succeeded, cache the valid data
     if (parseResult == CURRENT_CONDITIONS_OK) {
         m_last_valid.description = description;
         m_last_valid.raw_message = raw_message;
@@ -100,7 +93,7 @@ int CurrentConditions::update(int retries) {
         m_last_valid.dew_point = dew_point;
         m_last_valid.wind_speed = wind_speed;
         m_last_valid.valid = true;
-        m_last_update_time = millis();
+        m_last_update_time = m_clock.millis();
     }
 
     lastError = parseResult;
@@ -108,114 +101,87 @@ int CurrentConditions::update(int retries) {
 }
 
 bool CurrentConditions::validateData() {
-    // Check for valid temperature range (-100 to +100 should cover all realistic weather)
     if (temperature < -100 || temperature > 100) {
-        Log.error(F("Invalid temperature value: %d" CR), temperature);
+        CC_LOG_ERROR("Invalid temperature value: %d", temperature);
         return false;
     }
-
-    // Check for valid dew point (should normally be lower than or equal to temperature)
     if (dew_point < -100 || dew_point > 100 || dew_point > temperature + 5) {
-        Log.error(F("Invalid dew point value: %d" CR), dew_point);
+        CC_LOG_ERROR("Invalid dew point value: %d", dew_point);
         return false;
     }
-
-    // Check for valid wind speed (0 to 500 km/h should cover all cases, even hurricanes)
     if (wind_speed < 0 || wind_speed > 500) {
-        Log.error(F("Invalid wind speed value: %d" CR), wind_speed);
+        CC_LOG_ERROR("Invalid wind speed value: %d", wind_speed);
         return false;
     }
-
     return true;
 }
 
-int CurrentConditions::parse(Stream& input) {
-    // Clear the document to prevent issues with previous data
+int CurrentConditions::parse(const std::string& input) {
     m_doc.clear();
 
-    // Parse code generated with https://arduinojson.org/v6/assistant/
-    DeserializationError error = deserializeJson(m_doc, input, DeserializationOption::Filter(m_filter));
+    DeserializationError error = deserializeJson(
+        m_doc, input.c_str(), input.size(), DeserializationOption::Filter(m_filter));
 
     if (error) {
-        Log.error(F("deserializeJson() failed: %s" CR), error.f_str());
+        CC_LOG_ERROR("deserializeJson() failed: %s", error.c_str());
         return CURRENT_CONDITIONS_JSON_ERROR;
     }
 
-    // Check if the JSON structure is as expected
     JsonObject properties = m_doc["properties"];
     if (properties.isNull()) {
-        Log.error(F("Missing properties object in JSON response" CR));
+        CC_LOG_ERROR("Missing properties object in JSON response");
         return CURRENT_CONDITIONS_DATA_MISSING;
     }
 
-    // Extract data, now with null checks
     const char* prop_rawMessage = properties["rawMessage"] | "No data";
     const char* prop_textDescription = properties["textDescription"] | "Unknown";
-
     raw_message = prop_rawMessage;
     description = prop_textDescription;
 
-    // Check for temperature data
     JsonObject prop_temperature = properties["temperature"];
     if (!prop_temperature.isNull() && !prop_temperature["value"].isNull()) {
         temperature = prop_temperature["value"];
     } else {
-        Log.warning(F("No valid temperature received" CR));
-        temperature = -999;  // Error value
+        CC_LOG_WARNING("No valid temperature received");
+        temperature = -999;
     }
 
-    // Check for dewpoint data
     JsonObject prop_dewpoint = properties["dewpoint"];
     if (!prop_dewpoint.isNull() && !prop_dewpoint["value"].isNull()) {
         dew_point = prop_dewpoint["value"];
     } else {
-        Log.warning(F("No valid dewpoint received" CR));
-        dew_point = -999;  // Error value
+        CC_LOG_WARNING("No valid dewpoint received");
+        dew_point = -999;
     }
 
-    // Check for wind speed data
     JsonObject prop_windSpeed = properties["windSpeed"];
     if (!prop_windSpeed.isNull() && !prop_windSpeed["value"].isNull()) {
         wind_speed = prop_windSpeed["value"];
     } else {
-        Log.warning(F("No valid wind speed received" CR));
-        wind_speed = -999;  // Error value
+        CC_LOG_WARNING("No valid wind speed received");
+        wind_speed = -999;
     }
 
-    // Check if we got at least some valid data
     if (temperature == -999 && dew_point == -999 && wind_speed == -999) {
-        Log.error(F("No valid weather data received" CR));
+        CC_LOG_ERROR("No valid weather data received");
         return CURRENT_CONDITIONS_DATA_MISSING;
     }
 
-    String output;
-    serializeJson(properties, output);
-    output.concat(CR);
-    Log.info(output.c_str());
-    Log.info(F("Raw Message %s" CR), raw_message);
-    Log.info(
-        F("%s - Temp: %d C, Dew Point: %d C, Wind Speed: %d km/h" CR), description, temperature, dew_point, wind_speed);
+    CC_LOG_INFO("%s - Temp: %d C, Dew Point: %d C, Wind Speed: %d km/h",
+                description, temperature, dew_point, wind_speed);
 
     return CURRENT_CONDITIONS_OK;
 }
 
 const char* CurrentConditions::getErrorString(int errorCode) {
     switch (errorCode) {
-        case CURRENT_CONDITIONS_OK:
-            return "No error";
-        case CURRENT_CONDITIONS_ERROR:
-            return "General error";
-        case CURRENT_CONDITIONS_JSON_ERROR:
-            return "JSON parsing error";
-        case CURRENT_CONDITIONS_NETWORK_ERROR:
-            return "Network connection error";
-        case CURRENT_CONDITIONS_DATA_MISSING:
-            return "Required data missing";
-        case CURRENT_CONDITIONS_INVALID_DATA:
-            return "Invalid data values";
-        case CURRENT_CONDITIONS_CERT_ERROR:
-            return "SSL certificate validation failed - check CA cert or run cert update";
-        default:
-            return "Unknown error";
+        case CURRENT_CONDITIONS_OK:            return "No error";
+        case CURRENT_CONDITIONS_ERROR:         return "General error";
+        case CURRENT_CONDITIONS_JSON_ERROR:    return "JSON parsing error";
+        case CURRENT_CONDITIONS_NETWORK_ERROR: return "Network connection error";
+        case CURRENT_CONDITIONS_DATA_MISSING:  return "Required data missing";
+        case CURRENT_CONDITIONS_INVALID_DATA:  return "Invalid data values";
+        case CURRENT_CONDITIONS_CERT_ERROR:    return "SSL certificate validation failed - check CA cert or run cert update";
+        default:                               return "Unknown error";
     }
 }

--- a/src/network/CurrentConditions.h
+++ b/src/network/CurrentConditions.h
@@ -39,7 +39,7 @@ class CurrentConditions {
     IClock& m_clock;
     std::string m_url;
     DynamicJsonDocument m_doc;
-    StaticJsonDocument<96> m_filter;
+    StaticJsonDocument<200> m_filter;
 
     struct {
         std::string description;

--- a/src/network/CurrentConditions.h
+++ b/src/network/CurrentConditions.h
@@ -29,6 +29,8 @@ class CurrentConditions {
     // Get the text representation of an error code
     const char* getErrorString(int errorCode);
 
+    bool validateData();
+
     // Default values in case of errors
     const char* description = "Unknown";
     const char* raw_message = "No data";
@@ -41,7 +43,6 @@ class CurrentConditions {
 
    private:
     int parse(Stream& input);
-    bool validateData();  // New method to validate data
     JsonObject m_properties;
     std::shared_ptr<Network> m_network;
     String m_station;

--- a/src/network/CurrentConditions.h
+++ b/src/network/CurrentConditions.h
@@ -2,15 +2,13 @@
 // ABOUTME: Parses observation JSON and exposes temperature, wind, dew point, and description.
 #ifndef CURRENT_CONDITIONS_H
 #define CURRENT_CONDITIONS_H
+
 #include <ArduinoJson.h>
-#include <LCBUrl.h>
-#include <WString.h>
+#include <string>
 
-#include <memory>
+#include "IClock.h"
+#include "IHttpClient.h"
 
-#include "Network.h"
-
-// Extended error codes
 const int CURRENT_CONDITIONS_OK = 0;
 const int CURRENT_CONDITIONS_ERROR = -1;
 const int CURRENT_CONDITIONS_JSON_ERROR = -2;
@@ -21,46 +19,38 @@ const int CURRENT_CONDITIONS_CERT_ERROR = -6;
 
 class CurrentConditions {
    public:
-    CurrentConditions(std::shared_ptr<Network> network, const String station);
+    CurrentConditions(IHttpClient& http, IClock& clock, const std::string& station);
 
-    // Returns error code, now with options for retries
     int update(int retries = 2);
-
-    // Get the text representation of an error code
     const char* getErrorString(int errorCode);
-
     bool validateData();
 
-    // Default values in case of errors
     const char* description = "Unknown";
     const char* raw_message = "No data";
-    int temperature = -999;  // Use impossible values to indicate error state
+    int temperature = -999;
     int dew_point = -999;
     int wind_speed = -999;
-
-    // Last error code
     int lastError = CURRENT_CONDITIONS_OK;
 
    private:
-    int parse(Stream& input);
-    JsonObject m_properties;
-    std::shared_ptr<Network> m_network;
-    String m_station;
-    LCBUrl m_url;
+    int parse(const std::string& input);
+
+    IHttpClient& m_http;
+    IClock& m_clock;
+    std::string m_url;
     DynamicJsonDocument m_doc;
     StaticJsonDocument<96> m_filter;
 
-    // Store previous valid data as fallback
     struct {
-        String description;
-        String raw_message;
-        int temperature;
-        int dew_point;
-        int wind_speed;
+        std::string description;
+        std::string raw_message;
+        int temperature = -999;
+        int dew_point = -999;
+        int wind_speed = -999;
         bool valid = false;
     } m_last_valid;
 
-    // Time of last successful update
     unsigned long m_last_update_time = 0;
 };
+
 #endif  // CURRENT_CONDITIONS_H

--- a/src/network/IClock.h
+++ b/src/network/IClock.h
@@ -1,0 +1,12 @@
+// ABOUTME: Interface for time access, abstracting millis() for testability.
+// ABOUTME: Implement with SystemClock for production; stub for tests.
+#ifndef ICLOCK_H
+#define ICLOCK_H
+
+class IClock {
+   public:
+    virtual ~IClock() = default;
+    virtual unsigned long millis() const = 0;
+};
+
+#endif  // ICLOCK_H

--- a/src/network/IHttpClient.h
+++ b/src/network/IHttpClient.h
@@ -1,0 +1,16 @@
+// ABOUTME: Interface for HTTP GET requests, abstracting WiFi for testability.
+// ABOUTME: Implement with Network for production; stub for tests.
+#ifndef IHTTPCLIENT_H
+#define IHTTPCLIENT_H
+
+#include <string>
+
+class IHttpClient {
+   public:
+    virtual ~IHttpClient() = default;
+    // Performs an HTTPS GET. Returns 0 on success or a negative error code.
+    // On success, body contains the response body.
+    virtual int get(const std::string& url, std::string& body) = 0;
+};
+
+#endif  // IHTTPCLIENT_H

--- a/src/network/Network.cpp
+++ b/src/network/Network.cpp
@@ -6,6 +6,8 @@
 #include <HTTPClient.h>
 #include <WiFi.h>
 
+#include "../security/CACerts.h"
+
 Network::Network(const char* ssid, const char* password) {
     strncpy(m_ssid, ssid, sizeof(m_ssid));
     m_ssid[sizeof(m_ssid) - 1] = '\0';
@@ -172,6 +174,30 @@ bool Network::isCertError(WiFiClientSecure& client) {
         return true;
     }
     return false;
+}
+
+int Network::get(const std::string& url, std::string& body) {
+    WiFiClientSecure client;
+    StreamString stream;
+
+    // Extract hostname from URL: "https://host/path" → "host"
+    std::string hostname;
+    size_t scheme_end = url.find("://");
+    if (scheme_end != std::string::npos) {
+        size_t host_start = scheme_end + 3;
+        size_t host_end = url.find('/', host_start);
+        hostname = url.substr(host_start, host_end - host_start);
+    }
+
+    client.setCACert(CACerts::getCert(hostname));
+
+    String arduino_url(url.c_str());
+    int result = get(client, arduino_url, stream, 2, 10000);
+
+    if (result == NETWORK_OK) {
+        body = stream.c_str();
+    }
+    return result;
 }
 
 const char* Network::getErrorString(int errorCode) {

--- a/src/network/Network.h
+++ b/src/network/Network.h
@@ -9,6 +9,9 @@
 #include <WiFiClientSecure.h>
 
 #include <memory>
+#include <string>
+
+#include "IHttpClient.h"
 
 enum NetworkError {
     NETWORK_OK = 0,
@@ -19,7 +22,7 @@ enum NetworkError {
     NETWORK_CERT_ERROR = -5,
 };
 
-class Network {
+class Network : public IHttpClient {
    public:
     Network(const char* ssid, const char* password);
     void begin();
@@ -27,6 +30,9 @@ class Network {
 
     // Fetches URL content into stream; retries on transient failures.
     int get(WiFiClientSecure& client, const String& url, StreamString& stream, int retries = 2, int timeout = 10000);
+
+    // IHttpClient override: HTTPS GET with cert lookup, retries, and timeout.
+    int get(const std::string& url, std::string& body) override;
 
     // Get the text representation of an error code
     const char* getErrorString(int errorCode);

--- a/src/network/SystemClock.h
+++ b/src/network/SystemClock.h
@@ -1,0 +1,14 @@
+// ABOUTME: Production IClock implementation backed by Arduino's millis().
+// ABOUTME: Passed to CurrentConditions in the main sketch.
+#ifndef SYSTEMCLOCK_H
+#define SYSTEMCLOCK_H
+
+#include "IClock.h"
+#include <Arduino.h>
+
+class SystemClock : public IClock {
+   public:
+    unsigned long millis() const override { return ::millis(); }
+};
+
+#endif  // SYSTEMCLOCK_H

--- a/src/security/CACerts.cpp
+++ b/src/security/CACerts.cpp
@@ -1,10 +1,11 @@
 
 #include "CACerts.h"
 
-#include <Arduino.h>  // for PROGMEM
-#include <WString.h>
+#ifndef PROGMEM
+#define PROGMEM
+#endif
 
-const char *CACerts::getCert(const String &host) {
+const char* CACerts::getCert(const std::string& host) {
     auto search = ca_certs.find(host);
     if (search != ca_certs.end()) {
         return search->second;
@@ -435,7 +436,7 @@ const char PROGMEM r13_[] =
 
 }  // namespace
 
-const std::map<String, const char *> CACerts::ca_certs{
+const std::map<std::string, const char*> CACerts::ca_certs{
     {"api.weather.gov", r12_},
     {"example.com", digicert_global_g3_tls_ecc_sha384_2020_ca1_},
 };

--- a/src/security/CACerts.h
+++ b/src/security/CACerts.h
@@ -1,13 +1,17 @@
-#include <WString.h>
+// ABOUTME: SSL CA certificate store mapping hostnames to PEM-encoded CA certs.
+// ABOUTME: Used by Network to configure TLS before HTTPS requests.
+#ifndef CACERTS_H
+#define CACERTS_H
 
 #include <map>
+#include <string>
 
 class CACerts {
    public:
-    static const char *getCert(const String &host);
+    static const char* getCert(const std::string& host);
 
    private:
-    static const std::map<String, const char *> ca_certs;
+    static const std::map<std::string, const char*> ca_certs;
 };
 
-extern std::map<String, const char *> ca_certs;
+#endif  // CACERTS_H

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,3 +3,4 @@
 # ABOUTME: Each subdirectory defines an independent, flashable test target.
 
 add_subdirectory(calibration)
+add_subdirectory(device)

--- a/tests/device/CMakeLists.txt
+++ b/tests/device/CMakeLists.txt
@@ -1,0 +1,4 @@
+# CMakeLists.txt
+# ABOUTME: CMake entry point for device test sketches.
+# ABOUTME: Each subdirectory is a standalone flashable Arduino sketch.
+add_subdirectory(unit)

--- a/tests/device/unit/CMakeLists.txt
+++ b/tests/device/unit/CMakeLists.txt
@@ -1,0 +1,40 @@
+# CMakeLists.txt
+# ABOUTME: Build target for device unit tests using AUnit and the gtest adapter.
+# ABOUTME: Flash and monitor serial output at 115200 baud for PASS/FAIL results.
+
+file(COPY
+    "${ARDUINO_BOARD_RUNTIME_PLATFORM_PATH}/tools/partitions/default.csv"
+    DESTINATION "${CMAKE_CURRENT_BINARY_DIR}"
+)
+file(RENAME
+    "${CMAKE_CURRENT_BINARY_DIR}/default.csv"
+    "${CMAKE_CURRENT_BINARY_DIR}/partitions.csv"
+)
+
+add_executable(DeviceUnitTests
+    DeviceUnitTests.cpp
+    ../../../src/display/Kitties.cpp
+    ../../../src/display/KittyPics.cpp
+    ../../../src/network/CurrentConditions.cpp
+    ../../../src/network/Network.cpp
+    ../../../src/security/CACerts.cpp
+)
+
+target_include_directories(DeviceUnitTests PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${CMAKE_SOURCE_DIR}
+    ${CMAKE_BINARY_DIR}/generated
+)
+
+set(ARDUINO_LIB_AUnit_PATH "${CMAKE_SOURCE_DIR}/libs/AUnit" CACHE PATH "AUnit library path")
+
+target_link_arduino_libraries(DeviceUnitTests PRIVATE
+    core
+    AUnit
+    Inkplate
+    ArduinoJson
+    ArduinoLog
+    LCBUrl
+)
+
+target_enable_arduino_upload(DeviceUnitTests)

--- a/tests/device/unit/DeviceUnitTests.cpp
+++ b/tests/device/unit/DeviceUnitTests.cpp
@@ -7,9 +7,26 @@
 
 #include "display/Kitties.h"
 #include "network/CurrentConditions.h"
+#include "network/IClock.h"
+#include "network/IHttpClient.h"
 
 // Constraint: use only ASSERT_* macros (not EXPECT_*); TEST_F() is not
 // supported by the AUnit gtest adapter.
+
+// ── Test doubles ─────────────────────────────────────────────────────────────
+
+class StubHttpClient : public IHttpClient {
+   public:
+    int get(const std::string& url, std::string& body) override { return -2; }
+};
+
+class StubClock : public IClock {
+   public:
+    unsigned long millis() const override { return 0; }
+};
+
+static StubHttpClient stubHttp;
+static StubClock stubClock;
 
 // ── Kitties tests ────────────────────────────────────────────────────────────
 // m_count is RTC_DATA_ATTR — resets to 0 on power cycle, persists across deep
@@ -39,7 +56,7 @@ TEST(KittiesTest, Uint8OverflowDoesNotBreakCycling) {
 // pointer without dereferencing it (dereference only occurs in update()).
 
 TEST(ValidateDataTest, ValidDataPasses) {
-    CurrentConditions cc(nullptr, "KBFI");
+    CurrentConditions cc(stubHttp, stubClock, "KBFI");
     cc.temperature = 20;
     cc.dew_point = 15;
     cc.wind_speed = 10;
@@ -47,7 +64,7 @@ TEST(ValidateDataTest, ValidDataPasses) {
 }
 
 TEST(ValidateDataTest, TemperatureTooHighFails) {
-    CurrentConditions cc(nullptr, "KBFI");
+    CurrentConditions cc(stubHttp, stubClock, "KBFI");
     cc.temperature = 101;
     cc.dew_point = 15;
     cc.wind_speed = 10;
@@ -55,7 +72,7 @@ TEST(ValidateDataTest, TemperatureTooHighFails) {
 }
 
 TEST(ValidateDataTest, TemperatureTooLowFails) {
-    CurrentConditions cc(nullptr, "KBFI");
+    CurrentConditions cc(stubHttp, stubClock, "KBFI");
     cc.temperature = -101;
     cc.dew_point = -90;
     cc.wind_speed = 10;
@@ -63,7 +80,7 @@ TEST(ValidateDataTest, TemperatureTooLowFails) {
 }
 
 TEST(ValidateDataTest, DewPointTooHighFails) {
-    CurrentConditions cc(nullptr, "KBFI");
+    CurrentConditions cc(stubHttp, stubClock, "KBFI");
     cc.temperature = 20;
     cc.dew_point = 26;  // more than temperature + 5
     cc.wind_speed = 10;
@@ -71,7 +88,7 @@ TEST(ValidateDataTest, DewPointTooHighFails) {
 }
 
 TEST(ValidateDataTest, NegativeWindSpeedFails) {
-    CurrentConditions cc(nullptr, "KBFI");
+    CurrentConditions cc(stubHttp, stubClock, "KBFI");
     cc.temperature = 20;
     cc.dew_point = 15;
     cc.wind_speed = -1;
@@ -79,7 +96,7 @@ TEST(ValidateDataTest, NegativeWindSpeedFails) {
 }
 
 TEST(ValidateDataTest, ExcessiveWindSpeedFails) {
-    CurrentConditions cc(nullptr, "KBFI");
+    CurrentConditions cc(stubHttp, stubClock, "KBFI");
     cc.temperature = 20;
     cc.dew_point = 15;
     cc.wind_speed = 501;
@@ -89,7 +106,7 @@ TEST(ValidateDataTest, ExcessiveWindSpeedFails) {
 // ── CurrentConditions::getErrorString() tests ────────────────────────────────
 
 TEST(GetErrorStringTest, AllCodesReturnNonNull) {
-    CurrentConditions cc(nullptr, "KBFI");
+    CurrentConditions cc(stubHttp, stubClock, "KBFI");
     // ASSERT_NE(..., nullptr) doesn't work in AUnit gtest adapter (nullptr_t cast)
     ASSERT_TRUE(cc.getErrorString(CURRENT_CONDITIONS_OK) != nullptr);
     ASSERT_TRUE(cc.getErrorString(CURRENT_CONDITIONS_ERROR) != nullptr);
@@ -102,7 +119,7 @@ TEST(GetErrorStringTest, AllCodesReturnNonNull) {
 }
 
 TEST(GetErrorStringTest, OkCodeReturnsCorrectString) {
-    CurrentConditions cc(nullptr, "KBFI");
+    CurrentConditions cc(stubHttp, stubClock, "KBFI");
     // Cast literal to const char* so decltype(a) resolves correctly in AUnit adapter
     ASSERT_STREQ(cc.getErrorString(CURRENT_CONDITIONS_OK), (const char*)"No error");
 }

--- a/tests/device/unit/DeviceUnitTests.cpp
+++ b/tests/device/unit/DeviceUnitTests.cpp
@@ -3,9 +3,109 @@
 #include <AUnit.h>
 #include <aunit/contrib/gtest.h>
 #include <Arduino.h>
+#include <memory>
+
+#include "display/Kitties.h"
+#include "network/CurrentConditions.h"
 
 // Constraint: use only ASSERT_* macros (not EXPECT_*); TEST_F() is not
 // supported by the AUnit gtest adapter.
+
+// ── Kitties tests ────────────────────────────────────────────────────────────
+// m_count is RTC_DATA_ATTR — resets to 0 on power cycle, persists across deep
+// sleep. This sketch uses no deep sleep, so m_count starts at 0 each run.
+// Tests use relative assertions to be independent of starting counter state.
+
+TEST(KittiesTest, CyclesThroughFiveImages) {
+    const uint8_t* a = Kitties::getNextKitty();
+    for (int i = 0; i < 4; i++) Kitties::getNextKitty();
+    // 5 calls = one full cycle; next call should return the same image as a.
+    const uint8_t* b = Kitties::getNextKitty();
+    ASSERT_EQ(a, b);
+}
+
+TEST(KittiesTest, Uint8OverflowDoesNotBreakCycling) {
+    // 256 calls wraps uint8_t m_count back to its pre-call value (N+256 mod 256 = N).
+    for (int i = 0; i < 256; i++) Kitties::getNextKitty();
+    // Verify the 5-cycle invariant still holds after overflow.
+    const uint8_t* a = Kitties::getNextKitty();
+    for (int i = 0; i < 4; i++) Kitties::getNextKitty();
+    const uint8_t* b = Kitties::getNextKitty();
+    ASSERT_EQ(a, b);
+}
+
+// ── CurrentConditions::validateData() tests ──────────────────────────────────
+// Constructs CurrentConditions with nullptr network; constructor stores the
+// pointer without dereferencing it (dereference only occurs in update()).
+
+TEST(ValidateDataTest, ValidDataPasses) {
+    CurrentConditions cc(nullptr, "KBFI");
+    cc.temperature = 20;
+    cc.dew_point = 15;
+    cc.wind_speed = 10;
+    ASSERT_TRUE(cc.validateData());
+}
+
+TEST(ValidateDataTest, TemperatureTooHighFails) {
+    CurrentConditions cc(nullptr, "KBFI");
+    cc.temperature = 101;
+    cc.dew_point = 15;
+    cc.wind_speed = 10;
+    ASSERT_FALSE(cc.validateData());
+}
+
+TEST(ValidateDataTest, TemperatureTooLowFails) {
+    CurrentConditions cc(nullptr, "KBFI");
+    cc.temperature = -101;
+    cc.dew_point = -90;
+    cc.wind_speed = 10;
+    ASSERT_FALSE(cc.validateData());
+}
+
+TEST(ValidateDataTest, DewPointTooHighFails) {
+    CurrentConditions cc(nullptr, "KBFI");
+    cc.temperature = 20;
+    cc.dew_point = 26;  // more than temperature + 5
+    cc.wind_speed = 10;
+    ASSERT_FALSE(cc.validateData());
+}
+
+TEST(ValidateDataTest, NegativeWindSpeedFails) {
+    CurrentConditions cc(nullptr, "KBFI");
+    cc.temperature = 20;
+    cc.dew_point = 15;
+    cc.wind_speed = -1;
+    ASSERT_FALSE(cc.validateData());
+}
+
+TEST(ValidateDataTest, ExcessiveWindSpeedFails) {
+    CurrentConditions cc(nullptr, "KBFI");
+    cc.temperature = 20;
+    cc.dew_point = 15;
+    cc.wind_speed = 501;
+    ASSERT_FALSE(cc.validateData());
+}
+
+// ── CurrentConditions::getErrorString() tests ────────────────────────────────
+
+TEST(GetErrorStringTest, AllCodesReturnNonNull) {
+    CurrentConditions cc(nullptr, "KBFI");
+    // ASSERT_NE(..., nullptr) doesn't work in AUnit gtest adapter (nullptr_t cast)
+    ASSERT_TRUE(cc.getErrorString(CURRENT_CONDITIONS_OK) != nullptr);
+    ASSERT_TRUE(cc.getErrorString(CURRENT_CONDITIONS_ERROR) != nullptr);
+    ASSERT_TRUE(cc.getErrorString(CURRENT_CONDITIONS_JSON_ERROR) != nullptr);
+    ASSERT_TRUE(cc.getErrorString(CURRENT_CONDITIONS_NETWORK_ERROR) != nullptr);
+    ASSERT_TRUE(cc.getErrorString(CURRENT_CONDITIONS_DATA_MISSING) != nullptr);
+    ASSERT_TRUE(cc.getErrorString(CURRENT_CONDITIONS_INVALID_DATA) != nullptr);
+    ASSERT_TRUE(cc.getErrorString(CURRENT_CONDITIONS_CERT_ERROR) != nullptr);
+    ASSERT_TRUE(cc.getErrorString(-999) != nullptr);  // unknown code → "Unknown error"
+}
+
+TEST(GetErrorStringTest, OkCodeReturnsCorrectString) {
+    CurrentConditions cc(nullptr, "KBFI");
+    // Cast literal to const char* so decltype(a) resolves correctly in AUnit adapter
+    ASSERT_STREQ(cc.getErrorString(CURRENT_CONDITIONS_OK), (const char*)"No error");
+}
 
 void setup() {
     Serial.begin(115200);

--- a/tests/device/unit/DeviceUnitTests.cpp
+++ b/tests/device/unit/DeviceUnitTests.cpp
@@ -1,0 +1,17 @@
+// ABOUTME: Device unit test sketch using AUnit with the GoogleTest macro adapter.
+// ABOUTME: Flash to Inkplate and monitor serial at 115200 baud for PASS/FAIL results.
+#include <AUnit.h>
+#include <aunit/contrib/gtest.h>
+#include <Arduino.h>
+
+// Constraint: use only ASSERT_* macros (not EXPECT_*); TEST_F() is not
+// supported by the AUnit gtest adapter.
+
+void setup() {
+    Serial.begin(115200);
+    while (!Serial);
+}
+
+void loop() {
+    aunit::TestRunner::run();
+}

--- a/tests/unit/CACertsTest.cpp
+++ b/tests/unit/CACertsTest.cpp
@@ -1,0 +1,14 @@
+// ABOUTME: Host unit tests for CACerts certificate lookup.
+// ABOUTME: Verifies known-hostname lookups and unknown-hostname null returns.
+#include <gtest/gtest.h>
+#include "security/CACerts.h"
+
+TEST(CACertsTest, KnownHostReturnsCert) {
+    const char* cert = CACerts::getCert("api.weather.gov");
+    ASSERT_NE(cert, nullptr);
+}
+
+TEST(CACertsTest, UnknownHostReturnsNullptr) {
+    const char* cert = CACerts::getCert("notarealhost.example.com");
+    ASSERT_EQ(cert, nullptr);
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -14,16 +14,26 @@ add_subdirectory(
     EXCLUDE_FROM_ALL
 )
 
+include(FetchContent)
+FetchContent_Declare(
+  ArduinoJson
+  GIT_REPOSITORY https://github.com/bblanchon/ArduinoJson.git
+  GIT_TAG        v6.21.5
+)
+FetchContent_MakeAvailable(ArduinoJson)
+
 add_executable(unit_tests
     CACertsTest.cpp
+    CurrentConditionsTest.cpp
     ../../src/security/CACerts.cpp
+    ../../src/network/CurrentConditions.cpp
 )
 
 target_include_directories(unit_tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src
 )
 
-target_link_libraries(unit_tests PRIVATE gtest_main)
+target_link_libraries(unit_tests PRIVATE gtest_main ArduinoJson)
 
 include(GoogleTest)
 gtest_discover_tests(unit_tests)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -15,7 +15,8 @@ add_subdirectory(
 )
 
 add_executable(unit_tests
-    placeholder.cpp
+    CACertsTest.cpp
+    ../../src/security/CACerts.cpp
 )
 
 target_include_directories(unit_tests PRIVATE

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,0 +1,28 @@
+# CMakeLists.txt
+# ABOUTME: Standalone CMake project for host-side unit tests using GoogleTest.
+# ABOUTME: Build with: cmake -S tests/unit -B build-host && cmake --build build-host
+cmake_minimum_required(VERSION 3.16)
+project(WeatherStationTests CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+add_subdirectory(
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../libs/googletest
+    ${CMAKE_CURRENT_BINARY_DIR}/googletest
+    EXCLUDE_FROM_ALL
+)
+
+add_executable(unit_tests
+    placeholder.cpp
+)
+
+target_include_directories(unit_tests PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src
+)
+
+target_link_libraries(unit_tests PRIVATE gtest_main)
+
+include(GoogleTest)
+gtest_discover_tests(unit_tests)

--- a/tests/unit/CurrentConditionsTest.cpp
+++ b/tests/unit/CurrentConditionsTest.cpp
@@ -1,0 +1,200 @@
+// ABOUTME: Host unit tests for CurrentConditions logic.
+// ABOUTME: Uses hand-written stubs for IHttpClient and IClock — no WiFi required.
+#include <gtest/gtest.h>
+#include "network/CurrentConditions.h"
+#include "network/IClock.h"
+#include "network/IHttpClient.h"
+
+// ── Test doubles ─────────────────────────────────────────────────────────────
+
+class StubHttpClient : public IHttpClient {
+   public:
+    int next_result = 0;
+    std::string next_body;
+    int call_count = 0;
+
+    int get(const std::string& url, std::string& body) override {
+        call_count++;
+        body = next_body;
+        return next_result;
+    }
+};
+
+class StubClock : public IClock {
+   public:
+    unsigned long current_ms = 0;
+    unsigned long millis() const override { return current_ms; }
+};
+
+// ── validateData() tests ──────────────────────────────────────────────────────
+
+TEST(ValidateDataTest, ValidDataPasses) {
+    StubHttpClient http;
+    StubClock clock;
+    CurrentConditions cc(http, clock, "KBFI");
+    cc.temperature = 20;
+    cc.dew_point = 15;
+    cc.wind_speed = 10;
+    ASSERT_TRUE(cc.validateData());
+}
+
+TEST(ValidateDataTest, TemperatureTooHighFails) {
+    StubHttpClient http;
+    StubClock clock;
+    CurrentConditions cc(http, clock, "KBFI");
+    cc.temperature = 101;
+    cc.dew_point = 15;
+    cc.wind_speed = 10;
+    ASSERT_FALSE(cc.validateData());
+}
+
+TEST(ValidateDataTest, TemperatureTooLowFails) {
+    StubHttpClient http;
+    StubClock clock;
+    CurrentConditions cc(http, clock, "KBFI");
+    cc.temperature = -101;
+    cc.dew_point = -90;
+    cc.wind_speed = 10;
+    ASSERT_FALSE(cc.validateData());
+}
+
+TEST(ValidateDataTest, DewPointTooHighFails) {
+    StubHttpClient http;
+    StubClock clock;
+    CurrentConditions cc(http, clock, "KBFI");
+    cc.temperature = 20;
+    cc.dew_point = 26;
+    cc.wind_speed = 10;
+    ASSERT_FALSE(cc.validateData());
+}
+
+TEST(ValidateDataTest, NegativeWindSpeedFails) {
+    StubHttpClient http;
+    StubClock clock;
+    CurrentConditions cc(http, clock, "KBFI");
+    cc.temperature = 20;
+    cc.dew_point = 15;
+    cc.wind_speed = -1;
+    ASSERT_FALSE(cc.validateData());
+}
+
+TEST(ValidateDataTest, ExcessiveWindSpeedFails) {
+    StubHttpClient http;
+    StubClock clock;
+    CurrentConditions cc(http, clock, "KBFI");
+    cc.temperature = 20;
+    cc.dew_point = 15;
+    cc.wind_speed = 501;
+    ASSERT_FALSE(cc.validateData());
+}
+
+// ── getErrorString() tests ────────────────────────────────────────────────────
+
+TEST(GetErrorStringTest, AllCodesReturnNonNull) {
+    StubHttpClient http;
+    StubClock clock;
+    CurrentConditions cc(http, clock, "KBFI");
+    ASSERT_NE(cc.getErrorString(CURRENT_CONDITIONS_OK), nullptr);
+    ASSERT_NE(cc.getErrorString(CURRENT_CONDITIONS_ERROR), nullptr);
+    ASSERT_NE(cc.getErrorString(CURRENT_CONDITIONS_JSON_ERROR), nullptr);
+    ASSERT_NE(cc.getErrorString(CURRENT_CONDITIONS_NETWORK_ERROR), nullptr);
+    ASSERT_NE(cc.getErrorString(CURRENT_CONDITIONS_DATA_MISSING), nullptr);
+    ASSERT_NE(cc.getErrorString(CURRENT_CONDITIONS_INVALID_DATA), nullptr);
+    ASSERT_NE(cc.getErrorString(CURRENT_CONDITIONS_CERT_ERROR), nullptr);
+    ASSERT_NE(cc.getErrorString(-999), nullptr);
+}
+
+// ── update() tests ────────────────────────────────────────────────────────────
+
+static const std::string valid_json = R"({
+  "properties": {
+    "textDescription": "Clear",
+    "rawMessage": "KBFI 010053Z 00000KT 10SM SKC 05/01 A2992",
+    "temperature": { "value": 5.0, "unitCode": "wmoUnit:degC", "qualityControl": "V" },
+    "dewpoint":    { "value": 1.0, "unitCode": "wmoUnit:degC", "qualityControl": "V" },
+    "windSpeed":   { "value": 7.0, "unitCode": "wmoUnit:km_h-1", "qualityControl": "V" }
+  }
+})";
+
+TEST(UpdateTest, SuccessfulUpdateParsesData) {
+    StubHttpClient http;
+    StubClock clock;
+    http.next_result = 0;
+    http.next_body = valid_json;
+
+    CurrentConditions cc(http, clock, "KBFI");
+    ASSERT_EQ(cc.update(), CURRENT_CONDITIONS_OK);
+    ASSERT_STREQ(cc.description, "Clear");
+    ASSERT_EQ(cc.temperature, 5);
+    ASSERT_EQ(cc.dew_point, 1);
+    ASSERT_EQ(cc.wind_speed, 7);
+}
+
+TEST(UpdateTest, NetworkErrorReturnsCCNetworkError) {
+    StubHttpClient http;
+    StubClock clock;
+    http.next_result = -2;  // NETWORK_HTTP_ERROR value
+    http.next_body = "";
+
+    CurrentConditions cc(http, clock, "KBFI");
+    ASSERT_EQ(cc.update(), CURRENT_CONDITIONS_NETWORK_ERROR);
+}
+
+TEST(UpdateTest, MalformedJsonReturnsJsonError) {
+    StubHttpClient http;
+    StubClock clock;
+    http.next_result = 0;
+    http.next_body = "not json at all {{{";
+
+    CurrentConditions cc(http, clock, "KBFI");
+    ASSERT_EQ(cc.update(), CURRENT_CONDITIONS_JSON_ERROR);
+}
+
+TEST(UpdateTest, CacheReturnedWhenClockHasNotAdvanced) {
+    StubHttpClient http;
+    StubClock clock;
+    http.next_body = valid_json;
+    http.next_result = 0;
+
+    CurrentConditions cc(http, clock, "KBFI");
+    // First update succeeds and populates cache (m_last_update_time = 0)
+    ASSERT_EQ(cc.update(), CURRENT_CONDITIONS_OK);
+
+    // Simulate network failure with clock still under 30-minute threshold
+    http.next_result = -2;
+    clock.current_ms = 1799999;  // 1800000 - 1: within cache window
+
+    ASSERT_EQ(cc.update(), CURRENT_CONDITIONS_NETWORK_ERROR);  // error returned
+    ASSERT_STREQ(cc.description, "Clear");  // cached data still served
+}
+
+static const std::string cloudy_json = R"({
+  "properties": {
+    "textDescription": "Cloudy",
+    "rawMessage": "KBFI 010153Z 05005KT 10SM OVC015 08/04 A2989",
+    "temperature": { "value": 8.0, "unitCode": "wmoUnit:degC", "qualityControl": "V" },
+    "dewpoint":    { "value": 4.0, "unitCode": "wmoUnit:degC", "qualityControl": "V" },
+    "windSpeed":   { "value": 9.0, "unitCode": "wmoUnit:km_h-1", "qualityControl": "V" }
+  }
+})";
+
+TEST(UpdateTest, CacheNotUsedAfter30Minutes) {
+    StubHttpClient http;
+    StubClock clock;
+    http.next_body = valid_json;
+    http.next_result = 0;
+
+    CurrentConditions cc(http, clock, "KBFI");
+    ASSERT_EQ(cc.update(), CURRENT_CONDITIONS_OK);
+    ASSERT_STREQ(cc.description, "Clear");
+
+    // Advance past cache window; serve different JSON to prove a real fetch occurs
+    clock.current_ms = 1800001;
+    http.next_body = cloudy_json;
+    http.next_result = 0;
+
+    ASSERT_EQ(cc.update(), CURRENT_CONDITIONS_OK);
+    // If cache had been returned, description would still be "Clear".
+    ASSERT_STREQ(cc.description, "Cloudy");
+    ASSERT_EQ(http.call_count, 2);  // both updates hit the network
+}

--- a/tests/unit/placeholder.cpp
+++ b/tests/unit/placeholder.cpp
@@ -1,3 +1,0 @@
-// ABOUTME: Compilation target that ensures the test binary builds with no tests.
-// ABOUTME: Replaced by real test files in subsequent tasks.
-#include <gtest/gtest.h>

--- a/tests/unit/placeholder.cpp
+++ b/tests/unit/placeholder.cpp
@@ -1,0 +1,3 @@
+// ABOUTME: Compilation target that ensures the test binary builds with no tests.
+// ABOUTME: Replaced by real test files in subsequent tasks.
+#include <gtest/gtest.h>


### PR DESCRIPTION
## Summary

- **Phase 0:** Added GoogleTest and AUnit as git submodules; created a standalone CMake host test project (`cmake -S tests/unit -B build-host`). Added `build-essential` to the container image to support host compilation. Existing firmware build is unaffected.
- **Phase 1:** Refactored `CACerts` from `String` to `std::string` (host-portable); added 2 host tests. Added device AUnit sketch with 10 tests covering `Kitties` cycling, `CurrentConditions::validateData()`, and `getErrorString()`. Worked around AUnit gtest adapter limitations (`ASSERT_TRUE(ptr != nullptr)` instead of `ASSERT_NE`).
- **Phase 2:** Introduced `IClock` and `IHttpClient` interfaces; `Network` implements `IHttpClient` (cert lookup moved inside). `CurrentConditions` refactored to accept `IHttpClient&`/`IClock&` — no Arduino headers at compile time. Added 14 host tests covering `validateData`, `getErrorString`, `update()` parse/error/cache behaviour.

## Deviations from spec

- Host tests use a **standalone CMake project** (`cmake -S tests/unit -B build-host`) rather than a guard in the root `CMakeLists.txt` — the root file has a `FATAL_ERROR` if `config.cmake` is missing and can't run without the Arduino toolchain.
- `CurrentConditions` device tests use minimal `StubHttpClient`/`StubClock` (added when Phase 2 changed the constructor); `validateData`/`getErrorString` tests remain device-only in Phase 1 as planned.
- Log macros use `ArduinoLog`'s `*ln()` variants (no `F()`/`CR`) to avoid `__FlashStringHelper` concatenation errors on device.
- `StaticJsonDocument` filter bumped from 96 → 200 bytes; ArduinoJson v6.21.5 (host FetchContent) needs more space than v6.18.5 (pinned device lib).

## Test plan

- [x] `cmake -S tests/unit -B build-host && cmake --build build-host && ./build-host/unit_tests` → 14 passed
- [x] `cmake --build build --target DeviceUnitTests` + flash → 10 passed over serial
- [x] `cmake --build build --target WeatherStation` + flash → WiFi connected, `GET... code: 200`, weather displayed