### PR TITLE
feat: add build.sh wrapper for containerized build operations

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -53,33 +53,39 @@ EOF
 
 case "${1:-}" in
     configure)
-        run_in_container cmake \
-            -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake \
-            -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake \
-            -B build \
-            -G Ninja
+        run_in_container \
+            "cmake \
+              -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake \
+              -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake \
+              -B build \
+              -G Ninja"
         ;;
     build)
-        run_in_container cmake --build build
+        run_in_container "cmake --build build"
         ;;
     flash)
         require_device
-        run_in_container -v "${SERIAL_PORT}:${SERIAL_PORT}" "${USB_GROUP_FLAG[@]}" \
+        run_in_container \
+            "--device" "${SERIAL_PORT}" "${USB_GROUP_FLAG[@]}" \
             "SERIAL_PORT=${SERIAL_PORT} cmake --build build --target upload-WeatherStation"
         ;;
     monitor)
         require_device
-        arduino-cli monitor --port "${SERIAL_PORT}" --config baudrate=115200
+        run_in_container \
+            "--device" "${SERIAL_PORT}" "${USB_GROUP_FLAG[@]}" \
+            "arduino-cli monitor --port ${SERIAL_PORT} --config baudrate=115200"
         ;;
     test-host)
-        run_in_container cmake --build build --target test-host
+        run_in_container \
+            "cmake -S tests/unit -B build-host && cmake --build build-host && ./build-host/unit_tests"
         ;;
     build-device-tests)
-        run_in_container cmake --build build --target build-device-tests
+        run_in_container "cmake --build build --target DeviceUnitTests"
         ;;
     flash-device-tests)
         require_device
-        run_in_container -v "${SERIAL_PORT}:${SERIAL_PORT}" "${USB_GROUP_FLAG[@]}" \
+        run_in_container \
+            "--device" "${SERIAL_PORT}" "${USB_GROUP_FLAG[@]}" \
             "SERIAL_PORT=${SERIAL_PORT} cmake --build build --target upload-DeviceUnitTests"
         ;;
     *)

--- a/build.sh
+++ b/build.sh
@@ -77,7 +77,7 @@ case "${1:-}" in
         ;;
     test-host)
         run_in_container \
-            "cmake -S tests/unit -B build-host && cmake --build build-host && ./build-host/unit_tests"
+            "cmake -S tests/unit -B build-host -G Ninja && cmake --build build-host && ./build-host/unit_tests"
         ;;
     build-device-tests)
         run_in_container "cmake --build build --target DeviceUnitTests"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# ABOUTME: Wrapper script for containerized build, flash, and test operations
+# ABOUTME: Supports podman and docker; handles SELinux labels and USB device access
+
+set -euo pipefail
+
+SERIAL_PORT="${SERIAL_PORT:-/dev/ttyUSB0}"
+
+if command -v podman >/dev/null 2>&1; then
+    RUNNER=podman
+    SELINUX_LABEL=":Z"
+    USB_GROUP_FLAG=(--group-add keep-groups)
+else
+    RUNNER=docker
+    SELINUX_LABEL=""
+    USB_GROUP_FLAG=()
+fi
+
+IMAGE="weather-station-builder"
+
+# All args except the last are extra container flags; the last arg is the shell command.
+run_in_container() {
+    local cmd="${*: -1}"
+    local -a extra=("${@:1:$#-1}")
+    "$RUNNER" run --rm "${extra[@]}" \
+        -v "$(pwd):/project${SELINUX_LABEL}" \
+        -w /project \
+        "$IMAGE" \
+        bash -c "$cmd"
+}
+
+require_device() {
+    [ -e "${SERIAL_PORT}" ] || { echo "Device not found: ${SERIAL_PORT}"; exit 1; }
+}
+
+usage() {
+    cat <<EOF
+Usage: $0 <subcommand>
+
+Subcommands:
+  configure           Run cmake configure for firmware (also covers device test targets)
+  build               Compile firmware
+  flash               Flash firmware to device
+  monitor             Open serial monitor
+  test-host           Build and run host unit tests
+  build-device-tests  Compile DeviceUnitTests sketch
+  flash-device-tests  Flash DeviceUnitTests to device
+
+Environment:
+  SERIAL_PORT         Device path (default: /dev/ttyUSB0)
+EOF
+}
+
+case "${1:-}" in
+    configure)
+        run_in_container cmake \
+            -DCMAKE_TOOLCHAIN_FILE=cmake/Arduino-CMake-Toolchain/Arduino-toolchain.cmake \
+            -DARDUINO_BOARD_OPTIONS_FILE=cmake/BoardOptions.cmake \
+            -B build \
+            -G Ninja
+        ;;
+    build)
+        run_in_container cmake --build build
+        ;;
+    flash)
+        require_device
+        run_in_container -v "${SERIAL_PORT}:${SERIAL_PORT}" "${USB_GROUP_FLAG[@]}" \
+            "SERIAL_PORT=${SERIAL_PORT} cmake --build build --target upload-WeatherStation"
+        ;;
+    monitor)
+        require_device
+        arduino-cli monitor --port "${SERIAL_PORT}" --config baudrate=115200
+        ;;
+    test-host)
+        run_in_container cmake --build build --target test-host
+        ;;
+    build-device-tests)
+        run_in_container cmake --build build --target build-device-tests
+        ;;
+    flash-device-tests)
+        require_device
+        run_in_container -v "${SERIAL_PORT}:${SERIAL_PORT}" "${USB_GROUP_FLAG[@]}" \
+            "SERIAL_PORT=${SERIAL_PORT} cmake --build build --target upload-DeviceUnitTests"
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/tests/build-script/test_build_script.sh
+++ b/tests/build-script/test_build_script.sh
@@ -50,8 +50,13 @@ assert_exit_code       "flash: missing device exits 1"            1 env SERIAL_P
 assert_output_contains "flash: missing device error message" "Device not found" \
     env SERIAL_PORT=/dev/nonexistent "$SCRIPT" flash
 
-assert_exit_code "monitor: missing device exits 1"             1 env SERIAL_PORT=/dev/nonexistent "$SCRIPT" monitor
-assert_exit_code "flash-device-tests: missing device exits 1"  1 env SERIAL_PORT=/dev/nonexistent "$SCRIPT" flash-device-tests
+assert_exit_code       "monitor: missing device exits 1"             1 env SERIAL_PORT=/dev/nonexistent "$SCRIPT" monitor
+assert_output_contains "monitor: missing device error message" "Device not found" \
+    env SERIAL_PORT=/dev/nonexistent "$SCRIPT" monitor
+
+assert_exit_code       "flash-device-tests: missing device exits 1"  1 env SERIAL_PORT=/dev/nonexistent "$SCRIPT" flash-device-tests
+assert_output_contains "flash-device-tests: missing device error message" "Device not found" \
+    env SERIAL_PORT=/dev/nonexistent "$SCRIPT" flash-device-tests
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/build-script/test_build_script.sh
+++ b/tests/build-script/test_build_script.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# ABOUTME: Tests for build.sh pure-logic behavior (no container invocation required)
+# ABOUTME: Covers usage output, device guard, and exit codes
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")/../.." && pwd)/build.sh"
+PASS=0
+FAIL=0
+
+assert_exit_code() {
+    local desc="$1" expected="$2"
+    shift 2
+    local actual=0
+    "$@" >/dev/null 2>&1 || actual=$?
+    if [ "$actual" -eq "$expected" ]; then
+        echo "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $desc (expected exit $expected, got $actual)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_output_contains() {
+    local desc="$1" pattern="$2"
+    shift 2
+    local output
+    output=$("$@" 2>&1 || true)
+    if echo "$output" | grep -qF "$pattern"; then
+        echo "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $desc (expected output to contain '$pattern')"
+        echo "  Got: $output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# no args → usage + exit 1
+assert_exit_code       "no args exits 1"       1 "$SCRIPT"
+assert_output_contains "no args shows usage"   "Usage" "$SCRIPT"
+
+# unknown subcommand → usage + exit 1
+assert_exit_code       "unknown subcommand exits 1"       1 "$SCRIPT" foobar
+assert_output_contains "unknown subcommand shows usage" "Usage" "$SCRIPT" foobar
+
+# device guard — nonexistent device → exit 1 with clear message
+assert_exit_code       "flash: missing device exits 1"            1 env SERIAL_PORT=/dev/nonexistent "$SCRIPT" flash
+assert_output_contains "flash: missing device error message" "Device not found" \
+    env SERIAL_PORT=/dev/nonexistent "$SCRIPT" flash
+
+assert_exit_code "monitor: missing device exits 1"             1 env SERIAL_PORT=/dev/nonexistent "$SCRIPT" monitor
+assert_exit_code "flash-device-tests: missing device exits 1"  1 env SERIAL_PORT=/dev/nonexistent "$SCRIPT" flash-device-tests
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

- Adds `./build.sh` with subcommands: `configure`, `build`, `flash`, `monitor`, `test-host`, `build-device-tests`, `flash-device-tests`
- Auto-detects podman vs docker; applies `:Z` SELinux label and `--group-add keep-groups` for podman only
- Device-dependent subcommands guard against missing device nodes with a clear error before touching the container
- `SERIAL_PORT` defaults to `/dev/ttyUSB0` and is overridable via environment variable

Closes #30

## Test Plan

- [x] `bash tests/build-script/test_build_script.sh` — 10 passed, 0 failed (usage, exit codes, device guard)
- [x] `shellcheck build.sh` — clean
- [x] `./build.sh test-host` — 14/14 unit tests pass end-to-end through container
- [x] With device connected: `./build.sh configure && ./build.sh build && ./build.sh flash`
- [x] With device connected: `./build.sh build-device-tests && ./build.sh flash-device-tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)