### PR TITLE
fix: update api.weather.gov cert mapping from R12 to R13

### DIFF
--- a/src/security/CACerts.cpp
+++ b/src/security/CACerts.cpp
@@ -437,6 +437,6 @@ const char PROGMEM r13_[] =
 }  // namespace
 
 const std::map<std::string, const char*> CACerts::ca_certs{
-    {"api.weather.gov", r12_},
+    {"api.weather.gov", r13_},
     {"example.com", digicert_global_g3_tls_ecc_sha384_2020_ca1_},
 };


### PR DESCRIPTION
## Summary

Let's Encrypt rotated the `api.weather.gov` leaf cert to one signed by their R13 intermediate CA (2026-05-26). The embedded hostname→cert mapping still pointed to R12, which would cause WiFiClientSecure to fail cert verification.

R13 was already fully embedded in `CACerts.cpp` with a matching fingerprint — only the mapping needed updating.

## Change

`src/security/CACerts.cpp` line 440: `r12_` → `r13_`

## Verification

Flashed and confirmed `I: [HTTPS] GET... code: 200` on boot.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)