### PR TITLE
feat: battery meter — replace ADC_OFFSET with IBatteryReader + BatteryMeter SOC%

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # ── Firmware target ───────────────────────────────────────────────────────────
 add_executable(WeatherStation
     Weather_Station_2.cpp
+    src/display/BatteryMeter.cpp
     src/display/DisplayLocations.cpp
+    src/display/InkplateBatteryReader.cpp
     src/display/Kitties.cpp
     src/display/KittyPics.cpp
     src/network/BatteryLogger.cpp

--- a/Weather_Station_2.cpp
+++ b/Weather_Station_2.cpp
@@ -33,6 +33,8 @@ std::unique_ptr<T> make_unique(Args&&... args) {
 #include "src/display/KittyPics.h"
 #include "src/network/BatteryLogger.h"
 #include "src/network/Network.h"
+#include "src/display/BatteryMeter.h"
+#include "src/display/InkplateBatteryReader.h"
 
 #define US_PER_SEC 1000000ull
 #define TIME_TO_SLEEP_S 600
@@ -43,7 +45,7 @@ Inkplate display(INKPLATE_3BIT);
 char buffer[256];
 
 void setup() {
-    float ADC_OFFSET = -0.50;
+    InkplateBatteryReader batteryReader(display);
     auto network = std::make_shared<Network>(WIFI_SSID, WIFI_PASSWORD);
     rtc_get_reset_reason(0);
     DisplayLocation kitties(850, 50, 300, 300);
@@ -110,22 +112,15 @@ void setup() {
 
             // Get and show battery info at least
             int temperature = display.readTemperature();
-            float rawBattery = display.readBattery();
-            float voltage = rawBattery + ADC_OFFSET;
+            float voltage = batteryReader.readVoltage();
 
             display.setFont(Roboto_Light.at(42));
             display.setCursor(860, 400);
-            display.print(voltage, 2);
-            display.print('V');
+            display.print(BatteryMeter::voltageToPercent(voltage));
+            display.print('%');
             display.print(' ');
             display.print(temperature, DEC);
             display.print('C');
-
-            display.setFont(Roboto_Light.at(24));
-            display.setCursor(860, 455);
-            display.print("raw: ");
-            display.print(rawBattery, 3);
-            display.print('V');
 
             display.display();
 
@@ -191,23 +186,16 @@ void setup() {
     float voltage;
 
     temperature = display.readTemperature();
-    float rawBattery = display.readBattery();
-    voltage = rawBattery + ADC_OFFSET;
+    voltage = batteryReader.readVoltage();
 
     // Display system info
     display.setFont(Roboto_Light.at(42));
     display.setCursor(860, 400);
-    display.print(voltage, 2);
-    display.print('V');
+    display.print(BatteryMeter::voltageToPercent(voltage));
+    display.print('%');
     display.print(' ');
     display.print(temperature, DEC);
     display.print('C');
-
-    display.setFont(Roboto_Light.at(24));
-    display.setCursor(860, 455);
-    display.print("raw: ");
-    display.print(rawBattery, 3);
-    display.print('V');
 
     // If there was a warning but we have data, show it
     if (updateResult != CURRENT_CONDITIONS_OK) {
@@ -223,7 +211,7 @@ void setup() {
     time_t now;
     time(&now);
     BatteryLogger batteryLogger(BATTERY_LOGGER_URL);
-    batteryLogger.log(now, rawBattery, voltage);
+    batteryLogger.log(now, voltage);
 
     // Goto deep sleep
     rtc_gpio_isolate(GPIO_NUM_12);

--- a/docs/superpowers/plans/2026-05-29-battery-meter.md
+++ b/docs/superpowers/plans/2026-05-29-battery-meter.md
@@ -1,0 +1,556 @@
+# Battery Meter Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broken battery voltage display (ADC_OFFSET=-0.50 was wrong) with an empirical 0–100% SOC meter backed by a testable `IBatteryReader`/`BatteryMeter` abstraction.
+
+**Architecture:** A new `IBatteryReader` interface separates hardware from logic; `InkplateBatteryReader` wraps `display.readBattery()`; `BatteryMeter` does pure-math voltage→% lookup (testable on host). `BatteryLogger` is simplified to log raw voltage only. Both call sites in `Weather_Station_2.cpp` are updated.
+
+**Tech Stack:** C++11, Arduino/ESP32, GoogleTest (host unit tests), CMake, `./build.sh test-host`
+
+**Spec:** `docs/superpowers/specs/2026-05-29-battery-meter-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `src/display/IBatteryReader.h` | Create | Abstract interface for reading battery voltage |
+| `src/display/BatteryMeter.h` | Create | Static utility: voltage → SOC% |
+| `src/display/BatteryMeter.cpp` | Create | Empirical lookup table + piecewise linear interpolation |
+| `src/display/InkplateBatteryReader.h` | Create | Hardware adapter header |
+| `src/display/InkplateBatteryReader.cpp` | Create | Hardware adapter impl (wraps `display.readBattery()`) |
+| `src/network/BatteryLogger.h` | Modify | Remove `adjustedVoltage` param from `log()` |
+| `src/network/BatteryLogger.cpp` | Modify | Log `{ts, raw}` only; update ABOUTME |
+| `Weather_Station_2.cpp` | Modify | Remove ADC_OFFSET; add includes; wire reader + meter; update both display call sites; update BatteryLogger call |
+| `tests/unit/BatteryMeterTest.cpp` | Create | Unit tests for `BatteryMeter::voltageToPercent` |
+| `tests/unit/CMakeLists.txt` | Modify | Add `BatteryMeterTest.cpp` and `BatteryMeter.cpp` to test target |
+
+---
+
+## Chunk 1: Display components — IBatteryReader, BatteryMeter, InkplateBatteryReader
+
+### Task 1: Create `IBatteryReader` interface
+
+**Files:**
+- Create: `src/display/IBatteryReader.h`
+
+- [ ] **Step 1: Create the header**
+
+```cpp
+// ABOUTME: Abstract interface for reading battery voltage from hardware.
+// ABOUTME: Enables hardware-independent testing of battery-dependent code.
+#ifndef IBATTERY_READER_H
+#define IBATTERY_READER_H
+
+class IBatteryReader {
+public:
+    virtual ~IBatteryReader() = default;
+    virtual float readVoltage() const = 0;
+};
+
+#endif  // IBATTERY_READER_H
+```
+
+- [ ] **Step 2: Verify it compiles (build firmware)**
+
+```bash
+./build.sh build
+```
+
+Expected: build succeeds (file is not included anywhere yet, so no effect).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/display/IBatteryReader.h
+git commit -m "feat: add IBatteryReader interface"
+```
+
+---
+
+### Task 2: `BatteryMeter` — tests first, then implementation
+
+**Files:**
+- Create: `tests/unit/BatteryMeterTest.cpp`
+- Create: `src/display/BatteryMeter.h`
+- Create: `src/display/BatteryMeter.cpp`
+- Modify: `tests/unit/CMakeLists.txt`
+
+- [ ] **Step 1: Add `BatteryMeterTest.cpp` and `BatteryMeter.cpp` to the test CMakeLists**
+
+In `tests/unit/CMakeLists.txt`, expand `add_executable` from:
+```cmake
+add_executable(unit_tests
+    CACertsTest.cpp
+    CurrentConditionsTest.cpp
+    ../../src/security/CACerts.cpp
+    ../../src/network/CurrentConditions.cpp
+)
+```
+To:
+```cmake
+add_executable(unit_tests
+    CACertsTest.cpp
+    CurrentConditionsTest.cpp
+    BatteryMeterTest.cpp
+    ../../src/security/CACerts.cpp
+    ../../src/network/CurrentConditions.cpp
+    ../../src/display/BatteryMeter.cpp
+)
+```
+
+Do **not** add `InkplateBatteryReader.cpp` — it depends on `Inkplate.h` which is unavailable in the host build.
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tests/unit/BatteryMeterTest.cpp`:
+
+```cpp
+// ABOUTME: Unit tests for BatteryMeter::voltageToPercent.
+// ABOUTME: Covers all 11 breakpoints, midpoint interpolation, and clamping.
+#include <gtest/gtest.h>
+#include "display/BatteryMeter.h"
+
+// --- Breakpoints ---
+TEST(BatteryMeterTest, Breakpoint100) { EXPECT_EQ(BatteryMeter::voltageToPercent(4.294f), 100); }
+TEST(BatteryMeterTest, Breakpoint90)  { EXPECT_EQ(BatteryMeter::voltageToPercent(4.188f),  90); }
+TEST(BatteryMeterTest, Breakpoint80)  { EXPECT_EQ(BatteryMeter::voltageToPercent(4.118f),  80); }
+TEST(BatteryMeterTest, Breakpoint70)  { EXPECT_EQ(BatteryMeter::voltageToPercent(4.096f),  70); }
+TEST(BatteryMeterTest, Breakpoint60)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.994f),  60); }
+TEST(BatteryMeterTest, Breakpoint50)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.954f),  50); }
+TEST(BatteryMeterTest, Breakpoint40)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.890f),  40); }
+TEST(BatteryMeterTest, Breakpoint30)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.836f),  30); }
+TEST(BatteryMeterTest, Breakpoint20)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.704f),  20); }
+TEST(BatteryMeterTest, Breakpoint10)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.578f),  10); }
+TEST(BatteryMeterTest, Breakpoint0)   { EXPECT_EQ(BatteryMeter::voltageToPercent(3.224f),   0); }
+
+// --- Interpolation ---
+// Midpoint between 4.188V (90%) and 4.294V (100%) = 4.241V → 95%
+TEST(BatteryMeterTest, MidpointInterpolation) {
+    EXPECT_EQ(BatteryMeter::voltageToPercent(4.241f), 95);
+}
+
+// --- Clamping ---
+TEST(BatteryMeterTest, ClampBelow) { EXPECT_EQ(BatteryMeter::voltageToPercent(3.0f),  0); }
+TEST(BatteryMeterTest, ClampAbove) { EXPECT_EQ(BatteryMeter::voltageToPercent(4.5f), 100); }
+```
+
+- [ ] **Step 3: Create the stub header so the test compiles**
+
+Create `src/display/BatteryMeter.h`:
+
+```cpp
+// ABOUTME: Converts battery voltage to state-of-charge percentage.
+// ABOUTME: Uses an empirical lookup table derived from a full discharge cycle.
+#ifndef BATTERY_METER_H
+#define BATTERY_METER_H
+
+class BatteryMeter {
+public:
+    static int voltageToPercent(float voltage);
+};
+
+#endif  // BATTERY_METER_H
+```
+
+- [ ] **Step 4: Create a stub `.cpp` so it links**
+
+Create `src/display/BatteryMeter.cpp` with just a stub:
+
+```cpp
+// ABOUTME: Converts battery voltage to state-of-charge percentage.
+// ABOUTME: Uses an empirical lookup table derived from a full discharge cycle.
+#include "BatteryMeter.h"
+
+int BatteryMeter::voltageToPercent(float /*voltage*/) {
+    return -1;  // stub
+}
+```
+
+- [ ] **Step 5: Run tests and confirm they fail**
+
+```bash
+./build.sh test-host
+```
+
+Expected: all `BatteryMeterTest` cases FAIL (returning -1, not the expected values). Existing `CACertsTest` and `CurrentConditionsTest` must still pass.
+
+- [ ] **Step 6: Implement `BatteryMeter::voltageToPercent`**
+
+Replace `src/display/BatteryMeter.cpp` with the full implementation:
+
+```cpp
+// ABOUTME: Converts battery voltage to state-of-charge percentage.
+// ABOUTME: Uses an empirical lookup table derived from a full discharge cycle.
+#include "BatteryMeter.h"
+
+#include <cmath>
+
+namespace {
+
+struct VoltagePoint {
+    float voltage;
+    int percent;
+};
+
+static const VoltagePoint kTable[] = {
+    {4.294f, 100},
+    {4.188f,  90},
+    {4.118f,  80},
+    {4.096f,  70},
+    {3.994f,  60},
+    {3.954f,  50},
+    {3.890f,  40},
+    {3.836f,  30},
+    {3.704f,  20},
+    {3.578f,  10},
+    {3.224f,   0},
+};
+
+static const int kTableSize = static_cast<int>(sizeof(kTable) / sizeof(kTable[0]));
+
+}  // namespace
+
+int BatteryMeter::voltageToPercent(float voltage) {
+    if (voltage >= kTable[0].voltage) return 100;
+    if (voltage <= kTable[kTableSize - 1].voltage) return 0;
+
+    for (int i = 0; i < kTableSize - 1; ++i) {
+        if (kTable[i].voltage >= voltage && kTable[i + 1].voltage < voltage) {
+            if (voltage == kTable[i].voltage) return kTable[i].percent;
+            float ratio = (voltage - kTable[i + 1].voltage) /
+                          (kTable[i].voltage - kTable[i + 1].voltage);
+            float result = static_cast<float>(kTable[i + 1].percent) +
+                           ratio * static_cast<float>(kTable[i].percent - kTable[i + 1].percent);
+            return static_cast<int>(std::round(result));
+        }
+    }
+    return 0;  // unreachable: all in-range voltages are covered by the loop
+}
+```
+
+- [ ] **Step 7: Run tests and confirm they all pass**
+
+```bash
+./build.sh test-host
+```
+
+Expected: all 14 `BatteryMeterTest` cases PASS. All existing tests still pass. Output ends with something like:
+```
+[  PASSED  ] 14 tests.
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/display/BatteryMeter.h src/display/BatteryMeter.cpp \
+        tests/unit/BatteryMeterTest.cpp tests/unit/CMakeLists.txt
+git commit -m "feat: add BatteryMeter voltage-to-percent lookup
+
+Empirical 11-point table from 43-day discharge cycle.
+Piecewise linear interpolation with std::round."
+```
+
+---
+
+### Task 3: `InkplateBatteryReader` hardware adapter
+
+**Files:**
+- Create: `src/display/InkplateBatteryReader.h`
+- Create: `src/display/InkplateBatteryReader.cpp`
+
+No unit tests — this is a one-line hardware wrapper, verified by flashing.
+
+- [ ] **Step 1: Create the header**
+
+Create `src/display/InkplateBatteryReader.h`:
+
+```cpp
+// ABOUTME: Reads battery voltage from Inkplate hardware via display.readBattery().
+// ABOUTME: Implements IBatteryReader for use in production firmware.
+#ifndef INKPLATE_BATTERY_READER_H
+#define INKPLATE_BATTERY_READER_H
+
+#include "IBatteryReader.h"
+#include <Inkplate.h>
+
+class InkplateBatteryReader : public IBatteryReader {
+public:
+    explicit InkplateBatteryReader(Inkplate& display);
+    float readVoltage() const override;
+
+private:
+    Inkplate& m_display;
+};
+
+#endif  // INKPLATE_BATTERY_READER_H
+```
+
+- [ ] **Step 2: Create the implementation**
+
+Create `src/display/InkplateBatteryReader.cpp`:
+
+```cpp
+// ABOUTME: Reads battery voltage from Inkplate hardware via display.readBattery().
+// ABOUTME: Implements IBatteryReader for use in production firmware.
+#include "InkplateBatteryReader.h"
+
+InkplateBatteryReader::InkplateBatteryReader(Inkplate& display) : m_display(display) {}
+
+float InkplateBatteryReader::readVoltage() const {
+    return m_display.readBattery();
+}
+```
+
+- [ ] **Step 3: Verify firmware still builds**
+
+```bash
+./build.sh build
+```
+
+Expected: build succeeds (files exist but are not wired in yet).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/display/InkplateBatteryReader.h src/display/InkplateBatteryReader.cpp
+git commit -m "feat: add InkplateBatteryReader hardware adapter"
+```
+
+---
+
+## Chunk 2: BatteryLogger simplification + Weather_Station_2.cpp wiring
+
+> **Prerequisite:** Chunk 1 must be complete. `src/display/IBatteryReader.h`, `BatteryMeter.h/.cpp`, and `InkplateBatteryReader.h/.cpp` must already exist.
+
+### Task 4: Simplify `BatteryLogger`
+
+**Files:**
+- Modify: `src/network/BatteryLogger.h`
+- Modify: `src/network/BatteryLogger.cpp`
+
+- [ ] **Step 1: Update the header**
+
+In `src/network/BatteryLogger.h`, change the `log` declaration from:
+```cpp
+void log(time_t timestamp, float rawVoltage, float adjustedVoltage);
+```
+to:
+```cpp
+void log(time_t timestamp, float voltage);
+```
+
+- [ ] **Step 2: Update the implementation**
+
+Replace `src/network/BatteryLogger.cpp` with:
+
+```cpp
+// ABOUTME: Posts battery voltage readings to a local JSON store for discharge curve analysis.
+// ABOUTME: Sends a single {ts, raw} entry per reading; the server appends to the array.
+#include "BatteryLogger.h"
+
+#include <ArduinoJson.h>
+#include <ArduinoLog.h>
+#include <HTTPClient.h>
+
+BatteryLogger::BatteryLogger(const String& url) : m_url(url) {}
+
+void BatteryLogger::log(time_t timestamp, float voltage) {
+    StaticJsonDocument<64> doc;
+    doc["ts"] = (long)timestamp;
+    doc["raw"] = voltage;
+
+    String body;
+    serializeJson(doc, body);
+
+    HTTPClient http;
+    http.begin(m_url);
+    http.addHeader("Content-Type", "application/json");
+    int httpCode = http.POST(body);
+
+    if (httpCode != HTTP_CODE_CREATED) {
+        Log.warning(F("[BatteryLogger] POST failed: %d" CR), httpCode);
+    }
+
+    http.end();
+}
+```
+
+- [ ] **Step 3: Verify firmware build fails with the expected error**
+
+```bash
+./build.sh build
+```
+
+Expected: compile error on the `batteryLogger.log(now, rawBattery, voltage)` call site in `Weather_Station_2.cpp` — too many arguments. This confirms the signature change is in effect.
+
+- [ ] **Step 4: Run host tests to confirm nothing broke there**
+
+```bash
+./build.sh test-host
+```
+
+Expected: all tests pass (BatteryLogger is not used by host tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/network/BatteryLogger.h src/network/BatteryLogger.cpp
+git commit -m "feat: simplify BatteryLogger to log raw voltage only
+
+Remove adjustedVoltage param — ADC offset is now zero so adj was
+redundant. New payload: {ts, raw}."
+```
+
+---
+
+### Task 5: Wire `Weather_Station_2.cpp`
+
+**Files:**
+- Modify: `Weather_Station_2.cpp`
+
+The firmware currently fails to build (broken `batteryLogger.log` call from Task 4). This task fixes it and completes the feature.
+
+There are two `readBattery()` call sites. The **error path** is inside
+`if (updateResult != CURRENT_CONDITIONS_OK)` → inner `else` block (~line 113);
+the **normal path** is around line 194. Work top-to-bottom.
+
+- [ ] **Step 1: Add includes**
+
+After the existing includes (around line 34), add:
+
+```cpp
+#include "src/display/BatteryMeter.h"
+#include "src/display/InkplateBatteryReader.h"
+```
+
+- [ ] **Step 2: Remove `ADC_OFFSET` and construct the reader**
+
+Remove line 46:
+```cpp
+float ADC_OFFSET = -0.50;
+```
+
+In its place, construct the reader once (it will be used by both paths below):
+```cpp
+InkplateBatteryReader batteryReader(display);
+```
+
+- [ ] **Step 3: Update the error path (~lines 113–128)**
+
+Replace:
+```cpp
+float rawBattery = display.readBattery();
+float voltage = rawBattery + ADC_OFFSET;
+```
+with:
+```cpp
+float voltage = batteryReader.readVoltage();
+```
+
+Replace:
+```cpp
+display.print(voltage, 2);
+display.print('V');
+```
+with:
+```cpp
+display.print(BatteryMeter::voltageToPercent(voltage));
+display.print('%');
+```
+
+Delete the entire `"raw: "` debug block:
+```cpp
+display.setFont(Roboto_Light.at(24));
+display.setCursor(860, 455);
+display.print("raw: ");
+display.print(rawBattery, 3);
+display.print('V');
+```
+
+- [ ] **Step 4: Update the normal path (~lines 194–210)**
+
+Replace:
+```cpp
+float rawBattery = display.readBattery();
+voltage = rawBattery + ADC_OFFSET;
+```
+with:
+```cpp
+voltage = batteryReader.readVoltage();
+```
+
+Replace:
+```cpp
+display.print(voltage, 2);
+display.print('V');
+```
+with:
+```cpp
+display.print(BatteryMeter::voltageToPercent(voltage));
+display.print('%');
+```
+
+Delete the entire `"raw: "` debug block:
+```cpp
+display.setFont(Roboto_Light.at(24));
+display.setCursor(860, 455);
+display.print("raw: ");
+display.print(rawBattery, 3);
+display.print('V');
+```
+
+- [ ] **Step 5: Update the `BatteryLogger` call (~line 226)**
+
+Replace:
+```cpp
+batteryLogger.log(now, rawBattery, voltage);
+```
+with:
+```cpp
+batteryLogger.log(now, voltage);
+```
+
+- [ ] **Step 6: Build firmware — must succeed**
+
+```bash
+./build.sh build
+```
+
+Expected: clean build, no errors or new warnings.
+
+- [ ] **Step 7: Run host tests — must still pass**
+
+```bash
+./build.sh test-host
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Weather_Station_2.cpp
+git commit -m "feat: replace ADC_OFFSET with IBatteryReader + BatteryMeter
+
+- Remove ADC_OFFSET=-0.50 (empirically confirmed to be wrong)
+- Wire InkplateBatteryReader + BatteryMeter in both call sites
+- Display SOC% instead of raw voltage
+- Remove raw voltage debug display lines
+- Update BatteryLogger call to new single-arg signature
+
+Closes #22"
+```
+
+---
+
+## Done
+
+Flash and verify on device:
+```bash
+./build.sh flash && ./build.sh monitor
+```
+
+Expected boot output includes the battery % reading in place of the old voltage display. Confirm the reading is in a plausible range (should be near 100% on a freshly charged battery).

--- a/docs/superpowers/specs/2026-05-29-battery-meter-design.md
+++ b/docs/superpowers/specs/2026-05-29-battery-meter-design.md
@@ -101,9 +101,15 @@ public:
 ```
 
 Owns the lookup table as a file-scope `static const` array of `{voltage, percent}` pairs
-sorted descending by voltage. `voltageToPercent` walks the table, finds the bracketing pair,
-linearly interpolates, and rounds to the nearest integer before returning. Clamped: below
-3.224V returns 0, above 4.294V returns 100.
+sorted descending by voltage. `voltageToPercent` algorithm:
+
+1. If `voltage >= 4.294`, return 100 (clamp).
+2. If `voltage <= 3.224`, return 0 (clamp).
+3. Walk the table to find the first entry `i` where `table[i].voltage >= voltage` and
+   `table[i+1].voltage < voltage`. If `voltage` exactly equals `table[i].voltage`, return
+   `table[i].percent` directly.
+4. Linearly interpolate between `table[i]` and `table[i+1]`, then round to nearest integer
+   (`static_cast<int>(std::round(result))`) before returning.
 
 `BatteryMeter` and `BatteryReader` are intentionally decoupled — the meter is pure math
 with no hardware dependency.
@@ -133,8 +139,9 @@ Changes to make at both call sites:
   `InkplateBatteryReader` constructed once before both paths: 
   `InkplateBatteryReader reader(display);`
 - `rawBattery` is no longer needed. Remove it from both scopes.
-  - **Error path**: replace `float rawBattery = display.readBattery(); float voltage = rawBattery + ADC_OFFSET;` with `float voltage = reader.readVoltage();` (new local declaration, same as before).
+  - **Error path**: replace `float rawBattery = display.readBattery(); float voltage = rawBattery + ADC_OFFSET;` with `float voltage = reader.readVoltage();` (new local declaration inside the inner `else` block, as before).
   - **Normal path**: `voltage` is already declared at outer scope (line 191). Replace `float rawBattery = display.readBattery(); voltage = rawBattery + ADC_OFFSET;` with the assignment `voltage = reader.readVoltage();` — no new declaration.
+  - Note: after migration there are two variables named `voltage` in `setup()`. This is intentional — they exist in non-overlapping scopes (the inner `else` block always exits via `esp_deep_sleep_start()` before the outer `float voltage;` at line 191 is reached).
 - Each path prints battery + temperature together on one line:
   `display.print(voltage, 2); display.print('V'); display.print(' '); display.print(temperature, DEC); display.print('C');`
   Replace the voltage portion only:
@@ -163,7 +170,7 @@ host build.
 Test cases for `BatteryMeter::voltageToPercent`:
 
 - Each of the 11 breakpoint voltages returns its exact percentage.
-- Midpoint between two adjacent breakpoints interpolates correctly.
+- Midpoint between two adjacent breakpoints interpolates correctly: 4.241V (midpoint of 4.188V–4.294V) returns 95%.
 - Voltage below 3.224V clamps to 0%.
 - Voltage above 4.294V clamps to 100%.
 

--- a/docs/superpowers/specs/2026-05-29-battery-meter-design.md
+++ b/docs/superpowers/specs/2026-05-29-battery-meter-design.md
@@ -20,7 +20,8 @@ The device has been logging `{ts, raw, adj}` battery readings to a local JSON st
 1. Remove `ADC_OFFSET` and display correct battery voltage.
 2. Replace the voltage display with a 0–100% battery meter using the empirical lookup table.
 3. Separate the ADC hardware call behind an interface for testability.
-4. Keep `BatteryLogger` running to verify % readings over the next discharge cycle.
+4. Keep `BatteryLogger` running to verify % readings over the next discharge cycle; simplify
+   it to log only the raw voltage (the `adj` field is vestigial now that the offset is zero).
 
 ## Empirical Lookup Table
 
@@ -47,12 +48,11 @@ The curve is mostly linear in the 20–80% range, with the classic LiPo plateau 
 
 ## Architecture
 
-Three new/changed units:
-
 ```
-src/display/BatteryReader.h              ← new: abstract interface (header-only)
+src/display/IBatteryReader.h             ← new: abstract interface (header-only)
 src/display/InkplateBatteryReader.h/.cpp ← new: hardware adapter
 src/display/BatteryMeter.h/.cpp          ← new: lookup table + voltageToPercent()
+src/network/BatteryLogger.h/.cpp         ← changed: remove adjustedVoltage param, log {ts, raw} only
 Weather_Station_2.cpp                    ← changed: remove ADC_OFFSET, use reader+meter
 tests/unit/BatteryMeterTest.cpp          ← new: host unit tests
 tests/unit/CMakeLists.txt                ← changed: add BatteryMeterTest + BatteryMeter.cpp
@@ -60,23 +60,23 @@ tests/unit/CMakeLists.txt                ← changed: add BatteryMeterTest + Bat
 
 ## Component Design
 
-### `BatteryReader` (header-only interface)
+### `IBatteryReader` (header-only interface)
 
 ```cpp
-class BatteryReader {
+class IBatteryReader {
 public:
-    virtual ~BatteryReader() = default;
+    virtual ~IBatteryReader() = default;
     virtual float readVoltage() const = 0;
 };
 ```
 
-Pure abstract. No state. Lives in `src/display/BatteryReader.h`.
+Pure abstract. No state. Lives in `src/display/IBatteryReader.h`.
 
 ### `InkplateBatteryReader` (hardware adapter)
 
 ```cpp
-// InkplateBatteryReader.h must #include "BatteryReader.h"
-class InkplateBatteryReader : public BatteryReader {
+// InkplateBatteryReader.h must #include "IBatteryReader.h"
+class InkplateBatteryReader : public IBatteryReader {
 public:
     explicit InkplateBatteryReader(Inkplate& display);
     float readVoltage() const override;  // calls display.readBattery()
@@ -86,7 +86,7 @@ public:
 The only place `display.readBattery()` is called after migration. Takes `Inkplate&` by
 reference — does not own the display.
 
-Placement note: `BatteryReader`, `InkplateBatteryReader`, and `BatteryMeter` live in
+Placement note: `IBatteryReader`, `InkplateBatteryReader`, and `BatteryMeter` live in
 `src/display/` rather than `src/network/` because they serve display rendering (battery %
 is a display element). `BatteryLogger` in `src/network/` is a network concern (POSTing
 data); the two responsibilities don't overlap.
@@ -111,8 +111,24 @@ sorted descending by voltage. `voltageToPercent` algorithm:
 4. Linearly interpolate between `table[i]` and `table[i+1]`, then round to nearest integer
    (`static_cast<int>(std::round(result))`) before returning.
 
-`BatteryMeter` and `BatteryReader` are intentionally decoupled — the meter is pure math
+`BatteryMeter` and `IBatteryReader` are intentionally decoupled — the meter is pure math
 with no hardware dependency.
+
+### `BatteryLogger` changes
+
+Simplify the log signature to remove the now-meaningless adjusted value:
+
+```cpp
+// Before
+void log(time_t timestamp, float rawVoltage, float adjustedVoltage);
+
+// After
+void log(time_t timestamp, float voltage);
+```
+
+The JSON payload changes from `{"ts": …, "raw": …, "adj": …}` to `{"ts": …, "raw": …}`.
+The historical dataset already in the store is unaffected (server appends; old entries keep
+their `adj` field, new entries simply won't have it).
 
 ### `Weather_Station_2.cpp` changes
 
@@ -133,11 +149,11 @@ Changes to make at both call sites:
   #include "src/display/BatteryMeter.h"
   #include "src/display/InkplateBatteryReader.h"
   ```
-  (`BatteryReader.h` is included transitively because `InkplateBatteryReader.h` must `#include "BatteryReader.h"` — see Component Design above.)
+  (`IBatteryReader.h` is included transitively because `InkplateBatteryReader.h` must
+  `#include "IBatteryReader.h"` — see Component Design above.)
 - Remove the `ADC_OFFSET` constant declaration (line 46) and all uses.
-- Replace `display.readBattery()` with `reader.readVoltage()` where `reader` is an
-  `InkplateBatteryReader` constructed once before both paths: 
-  `InkplateBatteryReader reader(display);`
+- Construct `InkplateBatteryReader reader(display)` once before both paths (before the
+  `if (updateResult != CURRENT_CONDITIONS_OK)` block).
 - `rawBattery` is no longer needed. Remove it from both scopes.
   - **Error path**: replace `float rawBattery = display.readBattery(); float voltage = rawBattery + ADC_OFFSET;` with `float voltage = reader.readVoltage();` (new local declaration inside the inner `else` block, as before).
   - **Normal path**: `voltage` is already declared at outer scope (line 191). Replace `float rawBattery = display.readBattery(); voltage = rawBattery + ADC_OFFSET;` with the assignment `voltage = reader.readVoltage();` — no new declaration.
@@ -149,9 +165,7 @@ Changes to make at both call sites:
 - Remove the `"raw: "` debug block (lines 124–128 in error path, lines 206–210 in normal
   path) entirely.
 - In the normal path, update the `BatteryLogger` call from
-  `batteryLogger.log(now, rawBattery, voltage)` to `batteryLogger.log(now, voltage, voltage)`.
-  Both arguments are the same because the offset is zero. The `adj` field is vestigial;
-  keeping the log schema unchanged preserves the existing 6,000-entry historical dataset.
+  `batteryLogger.log(now, rawBattery, voltage)` to `batteryLogger.log(now, voltage)`.
 
 ## Error Handling
 
@@ -170,7 +184,8 @@ host build.
 Test cases for `BatteryMeter::voltageToPercent`:
 
 - Each of the 11 breakpoint voltages returns its exact percentage.
-- Midpoint between two adjacent breakpoints interpolates correctly: 4.241V (midpoint of 4.188V–4.294V) returns 95%.
+- Midpoint between two adjacent breakpoints interpolates correctly: 4.241V (midpoint of
+  4.188V–4.294V) returns 95%.
 - Voltage below 3.224V clamps to 0%.
 - Voltage above 4.294V clamps to 100%.
 

--- a/docs/superpowers/specs/2026-05-29-battery-meter-design.md
+++ b/docs/superpowers/specs/2026-05-29-battery-meter-design.md
@@ -1,0 +1,145 @@
+# Battery Meter Design
+
+**Date:** 2026-05-29
+**Issue:** #22 — Battery voltage reads low; ADC_OFFSET needs recalibration
+
+## Background
+
+The device has been logging `{ts, raw, adj}` battery readings to a local JSON store since
+2026-04-12 via `BatteryLogger`. A full discharge-and-recharge cycle has now been captured
+(43.4 days, 6,073 readings). Analysis of this data reveals:
+
+- `ADC_OFFSET = -0.50` is wrong. The raw `readBattery()` output is already accurate:
+  the first raw reading (4.294V on April 12) matches the known full-charge voltage
+  (4.296V from April 11) to within 2mV.
+- The correct offset is **0** — it should be removed entirely.
+- A full empirical voltage → SOC% lookup table can be derived from the discharge curve.
+
+## Goals
+
+1. Remove `ADC_OFFSET` and display correct battery voltage.
+2. Replace the voltage display with a 0–100% battery meter using the empirical lookup table.
+3. Separate the ADC hardware call behind an interface for testability.
+4. Keep `BatteryLogger` running to verify % readings over the next discharge cycle.
+
+## Empirical Lookup Table
+
+Derived from 43.4-day discharge curve. 0% is anchored at 3.224V — the last stable voltage
+before the board stopped successfully refreshing the display (the board went dark between
+3.224V and 3.104V).
+
+| Voltage (V) | SOC % |
+|-------------|-------|
+| 4.294       | 100   |
+| 4.188       |  90   |
+| 4.118       |  80   |
+| 4.096       |  70   |
+| 3.994       |  60   |
+| 3.954       |  50   |
+| 3.890       |  40   |
+| 3.836       |  30   |
+| 3.704       |  20   |
+| 3.578       |  10   |
+| 3.224       |   0   |
+
+The curve is mostly linear in the 20–80% range, with the classic LiPo plateau at 70–80%
+(only 22mV across 10% of capacity) and steep drops at both ends.
+
+## Architecture
+
+Three new/changed units:
+
+```
+src/display/BatteryReader.h             ← new: abstract interface (header-only)
+src/display/InkplateBatteryReader.h/.cpp ← new: hardware adapter
+src/display/BatteryMeter.h/.cpp         ← new: lookup table + voltageToPercent()
+Weather_Station_2.cpp                   ← changed: remove ADC_OFFSET, use reader+meter
+test/BatteryMeterTest.cpp               ← new: host unit tests
+```
+
+## Component Design
+
+### `BatteryReader` (header-only interface)
+
+```cpp
+class BatteryReader {
+public:
+    virtual ~BatteryReader() = default;
+    virtual float readVoltage() const = 0;
+};
+```
+
+Pure abstract. No state. Lives in `src/display/BatteryReader.h`.
+
+### `InkplateBatteryReader` (hardware adapter)
+
+```cpp
+class InkplateBatteryReader : public BatteryReader {
+public:
+    explicit InkplateBatteryReader(Inkplate& display);
+    float readVoltage() const override;  // calls display.readBattery()
+};
+```
+
+The only place `display.readBattery()` is called. Takes `Inkplate&` by reference — does not
+own the display.
+
+### `BatteryMeter` (static utility)
+
+```cpp
+class BatteryMeter {
+public:
+    static int voltageToPercent(float voltage);
+};
+```
+
+Owns the lookup table as a file-scope `static const` array of `{voltage, percent}` pairs
+sorted descending by voltage. `voltageToPercent` walks the table, finds the bracketing pair,
+and linearly interpolates. Clamped: below 3.224V returns 0, above 4.294V returns 100.
+
+`BatteryMeter` and `BatteryReader` are intentionally decoupled — the meter is pure math
+with no hardware dependency.
+
+### `Weather_Station_2.cpp` changes
+
+- Remove `ADC_OFFSET` constant and all uses.
+- Construct `InkplateBatteryReader reader(display)`.
+- Call `float voltage = reader.readVoltage()` where `readBattery()` was called.
+- Replace `display.print("raw: ...")` lines with `display.print(BatteryMeter::voltageToPercent(voltage)); display.print("%")`.
+- Pass `voltage` to `BatteryLogger::log(now, voltage, voltage)` — both raw and adj are the
+  same now that offset is zero; the adj field is vestigial but we keep the log format
+  unchanged to avoid breaking the existing data schema.
+
+## Error Handling
+
+`voltageToPercent` is pure math with no I/O. Out-of-range voltages (including 0V or
+pathological values from a hardware fault) are clamped to 0–100% without crashing.
+
+## Testing
+
+`test/BatteryMeterTest.cpp` — host unit tests, no Inkplate dependency.
+
+A small inline stub satisfies `BatteryReader` for any tests that need it:
+
+```cpp
+struct StubBatteryReader : public BatteryReader {
+    float voltage;
+    float readVoltage() const override { return voltage; }
+};
+```
+
+Test cases for `BatteryMeter::voltageToPercent`:
+
+- Each of the 11 breakpoint voltages returns its exact percentage.
+- Midpoint between two adjacent breakpoints interpolates correctly.
+- Voltage below 3.224V clamps to 0%.
+- Voltage above 4.294V clamps to 100%.
+
+`InkplateBatteryReader` is not unit-tested directly — it is a one-line wrapper around a
+hardware call, verified by running the device.
+
+## Out of Scope
+
+- Removing `BatteryLogger` — kept for next-cycle verification.
+- Hysteresis or smoothing on the % reading.
+- Displaying a graphical battery icon (future issue).

--- a/docs/superpowers/specs/2026-05-29-battery-meter-design.md
+++ b/docs/superpowers/specs/2026-05-29-battery-meter-design.md
@@ -50,11 +50,12 @@ The curve is mostly linear in the 20–80% range, with the classic LiPo plateau 
 Three new/changed units:
 
 ```
-src/display/BatteryReader.h             ← new: abstract interface (header-only)
+src/display/BatteryReader.h              ← new: abstract interface (header-only)
 src/display/InkplateBatteryReader.h/.cpp ← new: hardware adapter
-src/display/BatteryMeter.h/.cpp         ← new: lookup table + voltageToPercent()
-Weather_Station_2.cpp                   ← changed: remove ADC_OFFSET, use reader+meter
-test/BatteryMeterTest.cpp               ← new: host unit tests
+src/display/BatteryMeter.h/.cpp          ← new: lookup table + voltageToPercent()
+Weather_Station_2.cpp                    ← changed: remove ADC_OFFSET, use reader+meter
+tests/unit/BatteryMeterTest.cpp          ← new: host unit tests
+tests/unit/CMakeLists.txt                ← changed: add BatteryMeterTest + BatteryMeter.cpp
 ```
 
 ## Component Design
@@ -74,6 +75,7 @@ Pure abstract. No state. Lives in `src/display/BatteryReader.h`.
 ### `InkplateBatteryReader` (hardware adapter)
 
 ```cpp
+// InkplateBatteryReader.h must #include "BatteryReader.h"
 class InkplateBatteryReader : public BatteryReader {
 public:
     explicit InkplateBatteryReader(Inkplate& display);
@@ -81,8 +83,13 @@ public:
 };
 ```
 
-The only place `display.readBattery()` is called. Takes `Inkplate&` by reference — does not
-own the display.
+The only place `display.readBattery()` is called after migration. Takes `Inkplate&` by
+reference — does not own the display.
+
+Placement note: `BatteryReader`, `InkplateBatteryReader`, and `BatteryMeter` live in
+`src/display/` rather than `src/network/` because they serve display rendering (battery %
+is a display element). `BatteryLogger` in `src/network/` is a network concern (POSTing
+data); the two responsibilities don't overlap.
 
 ### `BatteryMeter` (static utility)
 
@@ -95,20 +102,49 @@ public:
 
 Owns the lookup table as a file-scope `static const` array of `{voltage, percent}` pairs
 sorted descending by voltage. `voltageToPercent` walks the table, finds the bracketing pair,
-and linearly interpolates. Clamped: below 3.224V returns 0, above 4.294V returns 100.
+linearly interpolates, and rounds to the nearest integer before returning. Clamped: below
+3.224V returns 0, above 4.294V returns 100.
 
 `BatteryMeter` and `BatteryReader` are intentionally decoupled — the meter is pure math
 with no hardware dependency.
 
 ### `Weather_Station_2.cpp` changes
 
-- Remove `ADC_OFFSET` constant and all uses.
-- Construct `InkplateBatteryReader reader(display)`.
-- Call `float voltage = reader.readVoltage()` where `readBattery()` was called.
-- Replace `display.print("raw: ...")` lines with `display.print(BatteryMeter::voltageToPercent(voltage)); display.print("%")`.
-- Pass `voltage` to `BatteryLogger::log(now, voltage, voltage)` — both raw and adj are the
-  same now that offset is zero; the adj field is vestigial but we keep the log format
-  unchanged to avoid breaking the existing data schema.
+There are two `readBattery()` call sites:
+
+**Error path** (inside `if (updateResult != CURRENT_CONDITIONS_OK)` > inner `else`, around
+line 113): this branch runs only when there is no weather data at all. It reads the battery,
+displays voltage + temperature on one line, then deep-sleeps. `BatteryLogger` is NOT called
+here.
+
+**Normal path** (around line 194): runs after weather data is fetched. Reads the battery,
+displays voltage + temperature, then calls `BatteryLogger`.
+
+Changes to make at both call sites:
+
+- Add includes near the top of `Weather_Station_2.cpp`:
+  ```cpp
+  #include "src/display/BatteryMeter.h"
+  #include "src/display/InkplateBatteryReader.h"
+  ```
+  (`BatteryReader.h` is included transitively because `InkplateBatteryReader.h` must `#include "BatteryReader.h"` — see Component Design above.)
+- Remove the `ADC_OFFSET` constant declaration (line 46) and all uses.
+- Replace `display.readBattery()` with `reader.readVoltage()` where `reader` is an
+  `InkplateBatteryReader` constructed once before both paths: 
+  `InkplateBatteryReader reader(display);`
+- `rawBattery` is no longer needed. Remove it from both scopes.
+  - **Error path**: replace `float rawBattery = display.readBattery(); float voltage = rawBattery + ADC_OFFSET;` with `float voltage = reader.readVoltage();` (new local declaration, same as before).
+  - **Normal path**: `voltage` is already declared at outer scope (line 191). Replace `float rawBattery = display.readBattery(); voltage = rawBattery + ADC_OFFSET;` with the assignment `voltage = reader.readVoltage();` — no new declaration.
+- Each path prints battery + temperature together on one line:
+  `display.print(voltage, 2); display.print('V'); display.print(' '); display.print(temperature, DEC); display.print('C');`
+  Replace the voltage portion only:
+  `display.print(BatteryMeter::voltageToPercent(voltage)); display.print('%'); display.print(' '); display.print(temperature, DEC); display.print('C');`
+- Remove the `"raw: "` debug block (lines 124–128 in error path, lines 206–210 in normal
+  path) entirely.
+- In the normal path, update the `BatteryLogger` call from
+  `batteryLogger.log(now, rawBattery, voltage)` to `batteryLogger.log(now, voltage, voltage)`.
+  Both arguments are the same because the offset is zero. The `adj` field is vestigial;
+  keeping the log schema unchanged preserves the existing 6,000-entry historical dataset.
 
 ## Error Handling
 
@@ -117,16 +153,12 @@ pathological values from a hardware fault) are clamped to 0–100% without crash
 
 ## Testing
 
-`test/BatteryMeterTest.cpp` — host unit tests, no Inkplate dependency.
+`tests/unit/BatteryMeterTest.cpp` — host unit tests, no Inkplate dependency.
 
-A small inline stub satisfies `BatteryReader` for any tests that need it:
-
-```cpp
-struct StubBatteryReader : public BatteryReader {
-    float voltage;
-    float readVoltage() const override { return voltage; }
-};
-```
+`tests/unit/CMakeLists.txt` must be updated to add `BatteryMeterTest.cpp` and
+`../../src/display/BatteryMeter.cpp` to the `add_executable` sources. Do **not** add
+`InkplateBatteryReader.cpp` — it depends on `Inkplate.h` which is not available in the
+host build.
 
 Test cases for `BatteryMeter::voltageToPercent`:
 

--- a/src/display/BatteryMeter.cpp
+++ b/src/display/BatteryMeter.cpp
@@ -1,0 +1,47 @@
+// ABOUTME: Converts battery voltage to state-of-charge percentage.
+// ABOUTME: Uses an empirical lookup table derived from a full discharge cycle.
+#include "BatteryMeter.h"
+
+#include <cmath>
+
+namespace {
+
+struct VoltagePoint {
+    float voltage;
+    int percent;
+};
+
+static const VoltagePoint kTable[] = {
+    {4.294f, 100},
+    {4.188f,  90},
+    {4.118f,  80},
+    {4.096f,  70},
+    {3.994f,  60},
+    {3.954f,  50},
+    {3.890f,  40},
+    {3.836f,  30},
+    {3.704f,  20},
+    {3.578f,  10},
+    {3.224f,   0},
+};
+
+static const int kTableSize = static_cast<int>(sizeof(kTable) / sizeof(kTable[0]));
+
+}  // namespace
+
+int BatteryMeter::voltageToPercent(float voltage) {
+    if (voltage >= kTable[0].voltage) return 100;
+    if (voltage <= kTable[kTableSize - 1].voltage) return 0;
+
+    for (int i = 0; i < kTableSize - 1; ++i) {
+        if (kTable[i].voltage >= voltage && kTable[i + 1].voltage < voltage) {
+            if (voltage == kTable[i].voltage) return kTable[i].percent;
+            float ratio = (voltage - kTable[i + 1].voltage) /
+                          (kTable[i].voltage - kTable[i + 1].voltage);
+            float result = static_cast<float>(kTable[i + 1].percent) +
+                           ratio * static_cast<float>(kTable[i].percent - kTable[i + 1].percent);
+            return static_cast<int>(std::round(result));
+        }
+    }
+    return 0;  // unreachable: all in-range voltages are covered by the loop
+}

--- a/src/display/BatteryMeter.h
+++ b/src/display/BatteryMeter.h
@@ -1,0 +1,11 @@
+// ABOUTME: Converts battery voltage to state-of-charge percentage.
+// ABOUTME: Uses an empirical lookup table derived from a full discharge cycle.
+#ifndef BATTERY_METER_H
+#define BATTERY_METER_H
+
+class BatteryMeter {
+public:
+    static int voltageToPercent(float voltage);
+};
+
+#endif  // BATTERY_METER_H

--- a/src/display/IBatteryReader.h
+++ b/src/display/IBatteryReader.h
@@ -1,0 +1,12 @@
+// ABOUTME: Abstract interface for reading battery voltage from hardware.
+// ABOUTME: Enables hardware-independent testing of battery-dependent code.
+#ifndef IBATTERY_READER_H
+#define IBATTERY_READER_H
+
+class IBatteryReader {
+public:
+    virtual ~IBatteryReader() = default;
+    virtual float readVoltage() const = 0;
+};
+
+#endif  // IBATTERY_READER_H

--- a/src/display/InkplateBatteryReader.cpp
+++ b/src/display/InkplateBatteryReader.cpp
@@ -1,0 +1,9 @@
+// ABOUTME: Reads battery voltage from Inkplate hardware via display.readBattery().
+// ABOUTME: Implements IBatteryReader for use in production firmware.
+#include "InkplateBatteryReader.h"
+
+InkplateBatteryReader::InkplateBatteryReader(Inkplate& display) : m_display(display) {}
+
+float InkplateBatteryReader::readVoltage() const {
+    return m_display.readBattery();
+}

--- a/src/display/InkplateBatteryReader.h
+++ b/src/display/InkplateBatteryReader.h
@@ -1,0 +1,18 @@
+// ABOUTME: Reads battery voltage from Inkplate hardware via display.readBattery().
+// ABOUTME: Implements IBatteryReader for use in production firmware.
+#ifndef INKPLATE_BATTERY_READER_H
+#define INKPLATE_BATTERY_READER_H
+
+#include "IBatteryReader.h"
+#include <Inkplate.h>
+
+class InkplateBatteryReader : public IBatteryReader {
+public:
+    explicit InkplateBatteryReader(Inkplate& display);
+    float readVoltage() const override;
+
+private:
+    Inkplate& m_display;
+};
+
+#endif  // INKPLATE_BATTERY_READER_H

--- a/src/network/BatteryLogger.cpp
+++ b/src/network/BatteryLogger.cpp
@@ -1,5 +1,5 @@
 // ABOUTME: Posts battery voltage readings to a local JSON store for discharge curve analysis.
-// ABOUTME: Sends a single {ts, raw, adj} entry per reading; the server appends and manages the array.
+// ABOUTME: Sends a single {ts, raw} entry per reading; the server appends to the array.
 #include "BatteryLogger.h"
 
 #include <ArduinoJson.h>
@@ -8,11 +8,10 @@
 
 BatteryLogger::BatteryLogger(const String& url) : m_url(url) {}
 
-void BatteryLogger::log(time_t timestamp, float rawVoltage, float adjustedVoltage) {
-    StaticJsonDocument<96> doc;
+void BatteryLogger::log(time_t timestamp, float voltage) {
+    StaticJsonDocument<64> doc;
     doc["ts"] = (long)timestamp;
-    doc["raw"] = rawVoltage;
-    doc["adj"] = adjustedVoltage;
+    doc["raw"] = voltage;
 
     String body;
     serializeJson(doc, body);

--- a/src/network/BatteryLogger.h
+++ b/src/network/BatteryLogger.h
@@ -11,7 +11,7 @@ class BatteryLogger {
     explicit BatteryLogger(const String& url);
 
     // Appends a reading to the remote store. Silently ignores network/server errors.
-    void log(time_t timestamp, float rawVoltage, float adjustedVoltage);
+    void log(time_t timestamp, float voltage);
 
    private:
     String m_url;

--- a/tests/unit/BatteryMeterTest.cpp
+++ b/tests/unit/BatteryMeterTest.cpp
@@ -1,0 +1,27 @@
+// ABOUTME: Unit tests for BatteryMeter::voltageToPercent.
+// ABOUTME: Covers all 11 breakpoints, midpoint interpolation, and clamping.
+#include <gtest/gtest.h>
+#include "display/BatteryMeter.h"
+
+// --- Breakpoints ---
+TEST(BatteryMeterTest, Breakpoint100) { EXPECT_EQ(BatteryMeter::voltageToPercent(4.294f), 100); }
+TEST(BatteryMeterTest, Breakpoint90)  { EXPECT_EQ(BatteryMeter::voltageToPercent(4.188f),  90); }
+TEST(BatteryMeterTest, Breakpoint80)  { EXPECT_EQ(BatteryMeter::voltageToPercent(4.118f),  80); }
+TEST(BatteryMeterTest, Breakpoint70)  { EXPECT_EQ(BatteryMeter::voltageToPercent(4.096f),  70); }
+TEST(BatteryMeterTest, Breakpoint60)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.994f),  60); }
+TEST(BatteryMeterTest, Breakpoint50)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.954f),  50); }
+TEST(BatteryMeterTest, Breakpoint40)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.890f),  40); }
+TEST(BatteryMeterTest, Breakpoint30)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.836f),  30); }
+TEST(BatteryMeterTest, Breakpoint20)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.704f),  20); }
+TEST(BatteryMeterTest, Breakpoint10)  { EXPECT_EQ(BatteryMeter::voltageToPercent(3.578f),  10); }
+TEST(BatteryMeterTest, Breakpoint0)   { EXPECT_EQ(BatteryMeter::voltageToPercent(3.224f),   0); }
+
+// --- Interpolation ---
+// Midpoint between 4.188V (90%) and 4.294V (100%) = 4.241V → 95%
+TEST(BatteryMeterTest, MidpointInterpolation) {
+    EXPECT_EQ(BatteryMeter::voltageToPercent(4.241f), 95);
+}
+
+// --- Clamping ---
+TEST(BatteryMeterTest, ClampBelow) { EXPECT_EQ(BatteryMeter::voltageToPercent(3.0f),  0); }
+TEST(BatteryMeterTest, ClampAbove) { EXPECT_EQ(BatteryMeter::voltageToPercent(4.5f), 100); }

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -20,8 +20,10 @@ FetchContent_MakeAvailable(ArduinoJson)
 add_executable(unit_tests
     CACertsTest.cpp
     CurrentConditionsTest.cpp
+    BatteryMeterTest.cpp
     ../../src/security/CACerts.cpp
     ../../src/network/CurrentConditions.cpp
+    ../../src/display/BatteryMeter.cpp
 )
 
 target_include_directories(unit_tests PRIVATE


### PR DESCRIPTION
## Summary

- Removes the broken `ADC_OFFSET = -0.50` constant (empirically confirmed wrong)
- Adds `IBatteryReader` interface + `InkplateBatteryReader` hardware adapter to decouple hardware from logic
- Adds `BatteryMeter::voltageToPercent()` with an 11-point empirical lookup table (piecewise linear interpolation) and full unit test coverage (14 tests)
- Both battery display call sites now show SOC% instead of raw voltage; raw debug lines removed
- Simplifies `BatteryLogger::log()` to single `voltage` param — removes redundant `adjustedVoltage`

## Test Plan
- [x] 28 host unit tests pass (`./build.sh test-host`)
- [x] Firmware builds clean (`./build.sh build`)
- [x] Flash to device and verify % reading is plausible (near 100% on fresh charge)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)